### PR TITLE
Surface BlueBubbles API errors and add send attachments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  pytest:
+    name: Pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ The integration provides a single service for sending messages.
 Sends a message via BlueBubbles (iMessage/RCS/SMS/MMS depending on recipients).
 
 - **addresses**: The address(es) to send to—phone numbers or emails, separated by commas or semicolons for groups (requires Private API enabled on your server). Required.
-- **message**: The message to send. Required.
+- **message**: The message to send. Optional when `attachment` or `media_url` is provided.
+- **attachment**: Absolute path to a local file to attach (for example a camera snapshot under `/config/www/`). The path must be allowed via [`allowlist_external_dirs`](https://www.home-assistant.io/docs/configuration/basic/#allowlist_external_dirs). Optional.
+- **media_url**: URL of an image/file to download and attach. Used when `attachment` is not set. Optional.
 
 Example automation in YAML:
 
@@ -70,12 +72,44 @@ automation:
           message: "Hello from Home Assistant!"
 ```
 
+#### Sending an image
+
+1. Ensure the file path is under an allowed directory, for example:
+
+```yaml
+# configuration.yaml
+homeassistant:
+  allowlist_external_dirs:
+    - /config/www
+```
+
+2. Call the service with an `attachment` path (and optional caption in `message`):
+
+```yaml
+service: bluebubbles.send_message
+data:
+  addresses: "+15551234567"
+  message: "Front door motion"
+  attachment: "/config/www/snapshot.jpg"
+```
+
+Or attach a remote/local HTTP image with `media_url`:
+
+```yaml
+service: bluebubbles.send_message
+data:
+  addresses: "+15551234567"
+  message: "Front door motion"
+  media_url: "https://example.com/snapshot.jpg"
+```
+
 You can also call this service from the Developer Tools > Services page for testing.
 
 ## Troubleshooting
 
-- **Connection Errors**: Double-check your host URL and password. Ensure the BlueBubbles server is running and accessible from your Home Assistant instance.
+- **Connection / Send Errors**: The service now surfaces BlueBubbles API error messages in Home Assistant (instead of a generic "Unknown error"). Double-check your host URL and password, and review the Home Assistant log for the redacted response body.
 - **Permission Issues**: If messages aren't sending, verify permissions on your macOS BlueBubbles app as noted in the setup section.
+- **Attachment Path Blocked**: If sending an image fails with an allowlist error, add the directory to `allowlist_external_dirs` and restart Home Assistant.
 - **Group Send Failures**: If sending to multiple addresses fails, ensure Private API is enabled on your BlueBubbles server (check server settings). The integration detects this automatically on setup and restarts.
 - **SSL Problems**: If using HTTPS, try toggling the SSL option.
 - For other issues, check the Home Assistant logs (search for "bluebubbles") or open an [issue][issue-tracker].

--- a/custom_components/bluebubbles/__init__.py
+++ b/custom_components/bluebubbles/__init__.py
@@ -1,12 +1,18 @@
 """The BlueBubbles integration."""
-import logging
-import re
 
-import aiohttp
+from __future__ import annotations
+
+import logging
+import mimetypes
+import re
+from pathlib import Path
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .api import BlueBubblesApi
 from .const import CONF_HOST, CONF_PASSWORD, CONF_SSL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,28 +26,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
 
-    async def fetch_and_update_private_api():
+    async def fetch_and_update_private_api() -> None:
         conf = entry.data
         host = conf[CONF_HOST]
         password = conf[CONF_PASSWORD]
         ssl = conf[CONF_SSL]
-        url = f"{host}/api/v1/server/info"
-        params = {"password": password}
-
         try:
-            async with aiohttp.ClientSession() as session, session.get(
-                url, params=params, ssl=ssl
-            ) as response:
-                response.raise_for_status()
-                json_data = await response.json()
-                if json_data.get("status") == 200:
-                    new_private_api = json_data["data"]["private_api"]
-                    if new_private_api != conf.get("private_api", False):
-                        new_data = dict(conf)  # Copy to avoid mutating original
-                        new_data["private_api"] = new_private_api
-                        hass.config_entries.async_update_entry(entry, data=new_data)
-                        _LOGGER.debug("Updated private_api to %s", new_private_api)
-        except aiohttp.ClientError as err:
+            session = async_get_clientsession(hass, verify_ssl=ssl)
+            api = BlueBubblesApi(host, password, ssl, session)
+            json_data = await api.async_get_server_info()
+            new_private_api = json_data.get("data", {}).get("private_api")
+            if new_private_api is None:
+                return
+            if new_private_api != conf.get("private_api", False):
+                new_data = dict(conf)
+                new_data["private_api"] = new_private_api
+                hass.config_entries.async_update_entry(entry, data=new_data)
+                _LOGGER.debug("Updated private_api to %s", new_private_api)
+        except HomeAssistantError as err:
             _LOGGER.warning("Failed to update server info: %s", err)
 
     await fetch_and_update_private_api()
@@ -54,40 +56,83 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ssl = conf[CONF_SSL]
         private_api = conf.get("private_api", False)
 
-        addresses_str = service_call.data.get("addresses", "").strip()
-        message = service_call.data.get("message", "").strip()
+        addresses_str = str(service_call.data.get("addresses", "")).strip()
+        message = str(service_call.data.get("message", "")).strip()
+        attachment_path = str(service_call.data.get("attachment", "")).strip()
+        media_url = str(service_call.data.get("media_url", "")).strip()
 
         if not addresses_str:
-            raise ValueError("At least one address is required")
-        if not message:
-            raise ValueError("Message is required")
+            raise HomeAssistantError("At least one address is required")
+        if not message and not attachment_path and not media_url:
+            raise HomeAssistantError(
+                "Message, attachment, or media_url is required"
+            )
 
-        # Split by , or ; and trim
-        addresses = [n.strip() for n in re.split(r'[,;]', addresses_str) if n.strip()]
-
+        addresses = [
+            n.strip() for n in re.split(r"[,;]", addresses_str) if n.strip()
+        ]
         if not addresses:
-            raise ValueError("No valid addresses provided")
+            raise HomeAssistantError("No valid addresses provided")
 
         if not private_api and len(addresses) > 1:
-            raise ValueError("Sending to multiple addresses is only supported when Private API is enabled on your BlueBubbles server. Please use a single address or enable Private API for group messaging.")
+            raise HomeAssistantError(
+                "Sending to multiple addresses is only supported when Private "
+                "API is enabled on your BlueBubbles server. Please use a single "
+                "address or enable Private API for group messaging."
+            )
 
-        url = f"{host}/api/v1/chat/new"
-        params = {"password": password}
         method = "private-api" if private_api else "apple-script"
-        payload = {"addresses": addresses, "message": message, "method": method}
+        session = async_get_clientsession(hass, verify_ssl=ssl)
+        api = BlueBubblesApi(host, password, ssl, session)
 
-        try:
-            async with aiohttp.ClientSession() as session, session.post(
-                url,
-                json=payload,
-                params=params,
-                ssl=ssl
-            ) as response:
-                response.raise_for_status()
-                _LOGGER.debug("Message sent successfully")
-        except aiohttp.ClientError as err:
-            _LOGGER.error("Error sending message: %s. Payload: %s", err, payload)
-            raise
+        chat_result = await api.async_create_chat(
+            addresses,
+            message=message or None,
+            method=method,
+        )
+
+        if not attachment_path and not media_url:
+            _LOGGER.debug("Message sent successfully")
+            return
+
+        chat_guid = (chat_result.get("data") or {}).get("guid")
+        if not chat_guid:
+            raise HomeAssistantError(
+                "BlueBubbles did not return a chat GUID required to send "
+                "attachments"
+            )
+
+        if attachment_path:
+            if not hass.config.is_allowed_path(attachment_path):
+                raise HomeAssistantError(
+                    f"Path '{attachment_path}' is not allowed. Add it to "
+                    "allowlist_external_dirs in configuration.yaml"
+                )
+            path = Path(attachment_path)
+            if not await hass.async_add_executor_job(path.is_file):
+                raise HomeAssistantError(
+                    f"Attachment file not found: {attachment_path}"
+                )
+            file_data = await hass.async_add_executor_job(path.read_bytes)
+            if not file_data:
+                raise HomeAssistantError(
+                    f"Attachment file is empty: {attachment_path}"
+                )
+            filename = path.name
+            content_type = mimetypes.guess_type(filename)[0]
+        else:
+            file_data, filename, content_type = await api.async_download_media(
+                media_url
+            )
+
+        await api.async_send_attachment(
+            chat_guid,
+            filename=filename,
+            file_data=file_data,
+            content_type=content_type,
+            method=method,
+        )
+        _LOGGER.debug("Attachment '%s' sent successfully", filename)
 
     hass.services.async_register(DOMAIN, "send_message", send_message)
 
@@ -96,6 +141,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    hass.services.async_remove(DOMAIN, "send_message")
-    hass.data[DOMAIN].pop(entry.entry_id)
+    if hass.services.has_service(DOMAIN, "send_message"):
+        hass.services.async_remove(DOMAIN, "send_message")
+    if DOMAIN in hass.data:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
     return True

--- a/custom_components/bluebubbles/api.py
+++ b/custom_components/bluebubbles/api.py
@@ -1,0 +1,313 @@
+"""BlueBubbles HTTP API helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import mimetypes
+import re
+import uuid
+from typing import Any
+
+import aiohttp
+from homeassistant.exceptions import HomeAssistantError
+
+_LOGGER = logging.getLogger(__name__)
+
+_SECRET_QUERY_RE = re.compile(
+    r"((?:password|guid|token)=)([^&\s]+)", re.IGNORECASE
+)
+_SECRET_JSON_RE = re.compile(
+    r'("(?:password|guid|token)"\s*:\s*")([^"]*)(")', re.IGNORECASE
+)
+
+
+def redact_secrets(text: str, extra_secrets: list[str] | None = None) -> str:
+    """Redact passwords/tokens from loggable strings."""
+    if not text:
+        return text
+
+    redacted = _SECRET_QUERY_RE.sub(r"\1***", text)
+    redacted = _SECRET_JSON_RE.sub(r"\1***\3", redacted)
+
+    for secret in extra_secrets or []:
+        if secret:
+            redacted = redacted.replace(secret, "***")
+
+    return redacted
+
+
+def extract_error_message(
+    payload: Any, *, http_status: int | None = None
+) -> str | None:
+    """Extract an actionable error message from a BlueBubbles JSON body."""
+    if not isinstance(payload, dict):
+        if http_status is not None and http_status >= 400:
+            return f"BlueBubbles request failed (HTTP {http_status})"
+        return None
+
+    detail: str | None = None
+    error = payload.get("error")
+
+    if isinstance(error, dict):
+        for key in ("message", "error"):
+            value = error.get(key)
+            if value:
+                detail = str(value)
+                break
+        if detail is None and error.get("type"):
+            detail = str(error["type"])
+    elif isinstance(error, str) and error.strip():
+        detail = error.strip()
+
+    message = payload.get("message")
+    if isinstance(message, str) and message.strip():
+        if detail and message.strip() not in detail:
+            detail = f"{message.strip()}: {detail}"
+        elif detail is None:
+            detail = message.strip()
+
+    api_status = payload.get("status")
+    if detail is None and isinstance(api_status, int) and api_status >= 400:
+        detail = f"BlueBubbles API status {api_status}"
+
+    if detail is None:
+        if http_status is not None and http_status >= 400:
+            return f"BlueBubbles request failed (HTTP {http_status})"
+        return None
+
+    if http_status is not None and http_status >= 400:
+        return f"{detail} (HTTP {http_status})"
+    return detail
+
+
+def _payload_indicates_error(payload: dict[str, Any], http_status: int) -> bool:
+    """Return True when the HTTP status or BlueBubbles body indicates failure."""
+    if http_status >= 400:
+        return True
+
+    api_status = payload.get("status")
+    if isinstance(api_status, int) and api_status >= 400:
+        return True
+
+    # Some failure payloads omit a high status but still include an error object.
+    if payload.get("error") and api_status not in (None, 200):
+        return True
+
+    return False
+
+
+async def async_parse_response(
+    response: aiohttp.ClientResponse,
+    *,
+    password: str | None = None,
+    context: str = "BlueBubbles request",
+) -> dict[str, Any]:
+    """Read and validate a BlueBubbles response, raising HomeAssistantError on failure."""
+    raw = await response.text()
+    safe_body = redact_secrets(raw, [password] if password else None)
+
+    payload: Any
+    if not raw:
+        payload = {}
+    else:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as err:
+            _LOGGER.error(
+                "%s returned non-JSON (HTTP %s): %s",
+                context,
+                response.status,
+                safe_body[:500],
+            )
+            raise HomeAssistantError(
+                f"{context} failed (HTTP {response.status}): invalid JSON response"
+            ) from err
+
+    if not isinstance(payload, dict):
+        _LOGGER.error(
+            "%s returned unexpected JSON (HTTP %s): %s",
+            context,
+            response.status,
+            safe_body[:500],
+        )
+        raise HomeAssistantError(
+            f"{context} failed (HTTP {response.status}): unexpected response"
+        )
+
+    if _payload_indicates_error(payload, response.status):
+        message = extract_error_message(payload, http_status=response.status) or (
+            f"{context} failed (HTTP {response.status})"
+        )
+        _LOGGER.error("%s: %s; body=%s", context, message, safe_body[:500])
+        raise HomeAssistantError(message)
+
+    return payload
+
+
+class BlueBubblesApi:
+    """Minimal BlueBubbles REST client used by the integration."""
+
+    def __init__(
+        self,
+        host: str,
+        password: str,
+        ssl: bool,
+        session: aiohttp.ClientSession,
+    ) -> None:
+        self._host = host.rstrip("/")
+        self._password = password
+        self._ssl = ssl
+        self._session = session
+
+    @property
+    def _params(self) -> dict[str, str]:
+        return {"password": self._password}
+
+    async def async_get_server_info(self) -> dict[str, Any]:
+        """Fetch /api/v1/server/info."""
+        url = f"{self._host}/api/v1/server/info"
+        try:
+            async with self._session.get(
+                url, params=self._params, ssl=self._ssl
+            ) as response:
+                return await async_parse_response(
+                    response,
+                    password=self._password,
+                    context="BlueBubbles server info",
+                )
+        except HomeAssistantError:
+            raise
+        except aiohttp.ClientError as err:
+            _LOGGER.error("Error connecting to BlueBubbles: %s", err)
+            raise HomeAssistantError(
+                f"Cannot connect to BlueBubbles server: {err}"
+            ) from err
+
+    async def async_create_chat(
+        self,
+        addresses: list[str],
+        *,
+        message: str | None = None,
+        method: str = "apple-script",
+    ) -> dict[str, Any]:
+        """Create or resolve a chat via /api/v1/chat/new, optionally sending text."""
+        url = f"{self._host}/api/v1/chat/new"
+        payload: dict[str, Any] = {
+            "addresses": addresses,
+            "method": method,
+        }
+        if message:
+            payload["message"] = message
+
+        try:
+            async with self._session.post(
+                url,
+                json=payload,
+                params=self._params,
+                ssl=self._ssl,
+            ) as response:
+                return await async_parse_response(
+                    response,
+                    password=self._password,
+                    context="BlueBubbles send message",
+                )
+        except HomeAssistantError:
+            raise
+        except aiohttp.ClientError as err:
+            safe_payload = redact_secrets(
+                json.dumps(payload), [self._password]
+            )
+            _LOGGER.error(
+                "Error sending message: %s. Payload: %s", err, safe_payload
+            )
+            raise HomeAssistantError(
+                f"Cannot connect to BlueBubbles server: {err}"
+            ) from err
+
+    async def async_send_attachment(
+        self,
+        chat_guid: str,
+        *,
+        filename: str,
+        file_data: bytes,
+        content_type: str | None = None,
+        method: str = "apple-script",
+    ) -> dict[str, Any]:
+        """Send a file attachment via /api/v1/message/attachment."""
+        url = f"{self._host}/api/v1/message/attachment"
+        mime = content_type or mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+        form = aiohttp.FormData()
+        form.add_field("chatGuid", chat_guid)
+        form.add_field("tempGuid", f"temp-{uuid.uuid4()}")
+        form.add_field("name", filename)
+        form.add_field("method", method)
+        form.add_field(
+            "attachment",
+            file_data,
+            filename=filename,
+            content_type=mime,
+        )
+
+        try:
+            async with self._session.post(
+                url,
+                data=form,
+                params=self._params,
+                ssl=self._ssl,
+                timeout=aiohttp.ClientTimeout(total=120),
+            ) as response:
+                return await async_parse_response(
+                    response,
+                    password=self._password,
+                    context="BlueBubbles send attachment",
+                )
+        except HomeAssistantError:
+            raise
+        except aiohttp.ClientError as err:
+            _LOGGER.error("Error sending attachment '%s': %s", filename, err)
+            raise HomeAssistantError(
+                f"Cannot connect to BlueBubbles server: {err}"
+            ) from err
+
+    async def async_download_media(self, media_url: str) -> tuple[bytes, str, str | None]:
+        """Download media from a URL for use as an attachment."""
+        try:
+            async with self._session.get(
+                media_url,
+                ssl=self._ssl,
+                timeout=aiohttp.ClientTimeout(total=60),
+            ) as response:
+                if response.status >= 400:
+                    body = await response.text()
+                    _LOGGER.error(
+                        "Failed to download media_url (HTTP %s): %s",
+                        response.status,
+                        redact_secrets(body, [self._password])[:500],
+                    )
+                    raise HomeAssistantError(
+                        f"Failed to download media_url (HTTP {response.status})"
+                    )
+                data = await response.read()
+                if not data:
+                    raise HomeAssistantError("Downloaded media_url was empty")
+
+                content_type = response.headers.get("Content-Type")
+                if content_type and ";" in content_type:
+                    content_type = content_type.split(";", 1)[0].strip()
+
+                filename = media_url.rstrip("/").split("/")[-1] or "attachment"
+                if "?" in filename:
+                    filename = filename.split("?", 1)[0]
+                if "." not in filename:
+                    ext = mimetypes.guess_extension(content_type or "") or ".bin"
+                    filename = f"{filename}{ext}"
+                return data, filename, content_type
+        except HomeAssistantError:
+            raise
+        except aiohttp.ClientError as err:
+            _LOGGER.error("Error downloading media_url: %s", err)
+            raise HomeAssistantError(
+                f"Cannot download media_url: {err}"
+            ) from err

--- a/custom_components/bluebubbles/config_flow.py
+++ b/custom_components/bluebubbles/config_flow.py
@@ -1,16 +1,33 @@
 """Config flow for BlueBubbles integration."""
+
+from __future__ import annotations
+
 import logging
 
-import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import selector
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .api import BlueBubblesApi
 from .const import CONF_PASSWORD, CONF_SSL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.URL)
+        ),
+        vol.Required(CONF_PASSWORD): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+        ),
+        vol.Optional(CONF_SSL, default=False): selector.BooleanSelector(),
+    }
+)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -18,70 +35,48 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input=None) -> config_entries.ConfigFlowResult:
+    async def async_step_user(
+        self, user_input=None
+    ) -> config_entries.ConfigFlowResult:
         """Handle the initial step."""
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            errors = {}
-
             host = user_input[CONF_HOST]
             password = user_input[CONF_PASSWORD]
             ssl = user_input[CONF_SSL]
-            url = f"{host}/api/v1/server/info"
-            params = {"password": password}
 
             try:
-                async with aiohttp.ClientSession() as session, session.get(
-                    url,
-                    params=params,
-                    ssl=ssl
-                ) as response:
-                    response.raise_for_status()
-                    json_data = await response.json()
-                    if json_data.get("status") != 200:
-                        raise ValueError(f"Invalid status in response: {json_data.get('status')}")
-                    data = json_data["data"]
-                    private_api = data["private_api"]
-                    detected_imessage = data["detected_imessage"]
-                    entry_data = user_input.copy()
-                    entry_data["private_api"] = private_api
-                    _LOGGER.debug("Successfully connected to BlueBubbles")
-                    return self.async_create_entry(title=detected_imessage, data=entry_data)
-            except (aiohttp.ClientError, ValueError, KeyError) as err:
+                session = async_get_clientsession(self.hass, verify_ssl=ssl)
+                api = BlueBubblesApi(host, password, ssl, session)
+                json_data = await api.async_get_server_info()
+                data = json_data["data"]
+                private_api = data["private_api"]
+                detected_imessage = data["detected_imessage"]
+                entry_data = dict(user_input)
+                entry_data["private_api"] = private_api
+                _LOGGER.debug("Successfully connected to BlueBubbles")
+                return self.async_create_entry(
+                    title=detected_imessage, data=entry_data
+                )
+            except HomeAssistantError as err:
                 _LOGGER.error("Error connecting to BlueBubbles: %s", err)
                 errors["base"] = "cannot_connect"
-            except Exception as err:
+            except (KeyError, TypeError, ValueError) as err:
+                _LOGGER.error("Unexpected BlueBubbles server info payload: %s", err)
+                errors["base"] = "cannot_connect"
+            except Exception as err:  # noqa: BLE001 - surface unexpected setup failures
                 _LOGGER.error("Unexpected error: %s", err)
                 errors["base"] = "unknown"
 
             return self.async_show_form(
                 step_id="user",
-                data_schema=vol.Schema(
-                    {
-                        vol.Required(CONF_HOST): selector.TextSelector(
-                            selector.TextSelectorConfig(type=selector.TextSelectorType.URL)
-                        ),
-                        vol.Required(CONF_PASSWORD): selector.TextSelector(
-                            selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
-                        ),
-                        vol.Optional(CONF_SSL, default=False): selector.BooleanSelector(),
-                    }
-                ),
+                data_schema=STEP_USER_DATA_SCHEMA,
                 errors=errors,
             )
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_HOST): selector.TextSelector(
-                        selector.TextSelectorConfig(type=selector.TextSelectorType.URL)
-                    ),
-                    vol.Required(CONF_PASSWORD): selector.TextSelector(
-                        selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
-                    ),
-                    vol.Optional(CONF_SSL, default=False): selector.BooleanSelector(),
-                }
-            ),
+            data_schema=STEP_USER_DATA_SCHEMA,
             errors={},
         )

--- a/custom_components/bluebubbles/manifest.json
+++ b/custom_components/bluebubbles/manifest.json
@@ -10,8 +10,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/helv-io/ha-bluebubbles/issues",
   "requirements": [
-    "aiohttp"
+    "aiohttp>=3.9.0,<4.0.0"
   ],
   "single_config_entry": true,
-  "version": "0.3.5"
+  "version": "0.4.0"
 }

--- a/custom_components/bluebubbles/services.yaml
+++ b/custom_components/bluebubbles/services.yaml
@@ -1,6 +1,6 @@
 send_message:
   name: Send Message
-  description: Sends a Message (iMessage / RCS / MMS / SMS) via BlueBubbles.
+  description: Sends a Message (iMessage / RCS / MMS / SMS) via BlueBubbles, with optional image/file attachment.
   fields:
     addresses:
       name: Address(es)
@@ -11,8 +11,22 @@ send_message:
         text:
     message:
       name: Message
-      description: The message to send.
-      required: true
+      description: The message to send. Optional when attachment or media_url is provided.
+      required: false
       example: "Hello!"
+      selector:
+        text:
+    attachment:
+      name: Attachment
+      description: Absolute path to a local file to attach (must be under allowlist_external_dirs).
+      required: false
+      example: "/config/www/snapshot.jpg"
+      selector:
+        text:
+    media_url:
+      name: Media URL
+      description: URL of an image/file to download and attach (used when attachment is not set).
+      required: false
+      example: "https://example.com/image.jpg"
       selector:
         text:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+testpaths = tests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,4 @@
+pytest>=8.0.0
+pytest-asyncio>=0.23.0
+aiohttp>=3.9.0,<4.0.0
+pytest-homeassistant-custom-component>=0.13.190

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the BlueBubbles Home Assistant integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Shared fixtures for BlueBubbles tests."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable loading custom integrations in tests."""
+    return
+
+
+@pytest.fixture(autouse=True)
+def expected_lingering_timers():
+    """Allow brief aiohttp shutdown timers during HA test teardown."""
+    return True
+
+
+@pytest.fixture(autouse=True)
+def ignore_aiohttp_shutdown_threads(monkeypatch):
+    """Ignore aiohttp's daemon safe-shutdown helper threads in PHACC cleanup."""
+    real_enumerate = threading.enumerate
+
+    def _enumerate():
+        return [
+            thread
+            for thread in real_enumerate()
+            if "_run_safe_shutdown_loop" not in thread.name
+        ]
+
+    monkeypatch.setattr(threading, "enumerate", _enumerate)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,133 @@
+"""Unit tests for BlueBubbles API helpers."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.bluebubbles.api import (
+    BlueBubblesApi,
+    async_parse_response,
+    extract_error_message,
+    redact_secrets,
+)
+
+
+def test_redact_secrets_query_and_json() -> None:
+    """Passwords in query strings and JSON are redacted."""
+    text = (
+        "POST /api?password=super-secret&token=abc123 "
+        '{"password":"super-secret","guid":"abc123","ok":true}'
+    )
+    redacted = redact_secrets(text, extra_secrets=["super-secret"])
+    assert "super-secret" not in redacted
+    assert "abc123" not in redacted
+    assert "password=***" in redacted
+    assert '"password":"***"' in redacted
+
+
+def test_extract_error_message_from_nested_error() -> None:
+    """Nested BlueBubbles error objects yield actionable text."""
+    payload = {
+        "status": 400,
+        "message": "You've made a bad request!",
+        "error": {
+            "type": "Validation Error",
+            "message": "Attachment not provided or was empty!",
+        },
+    }
+    message = extract_error_message(payload, http_status=400)
+    assert message is not None
+    assert "Attachment not provided or was empty!" in message
+    assert "HTTP 400" in message
+
+
+def test_extract_error_message_legacy_error_key() -> None:
+    """Legacy error.error key is supported."""
+    payload = {
+        "status": 500,
+        "message": "Server error",
+        "error": {"type": "Server Error", "error": "iMessage helper crashed"},
+    }
+    message = extract_error_message(payload, http_status=500)
+    assert message is not None
+    assert "iMessage helper crashed" in message
+
+
+@pytest.mark.asyncio
+async def test_async_parse_response_raises_homeassistant_error() -> None:
+    """API error bodies become HomeAssistantError with useful text."""
+    response = MagicMock()
+    response.status = 400
+    response.text = AsyncMock(
+        return_value=json.dumps(
+            {
+                "status": 400,
+                "message": "Bad request",
+                "error": {"message": "Invalid password"},
+            }
+        )
+    )
+
+    with pytest.raises(HomeAssistantError, match="Invalid password") as err:
+        await async_parse_response(
+            response, password="hunter2", context="BlueBubbles send message"
+        )
+
+    assert "Unknown error" not in str(err.value)
+    assert not isinstance(err.value, aiohttp.ClientError)
+
+
+@pytest.mark.asyncio
+async def test_async_parse_response_success() -> None:
+    """Successful payloads are returned unchanged."""
+    payload = {"status": 200, "message": "ok", "data": {"guid": "chat-1"}}
+    response = MagicMock()
+    response.status = 200
+    response.text = AsyncMock(return_value=json.dumps(payload))
+
+    result = await async_parse_response(response, password="secret")
+    assert result == payload
+
+
+@pytest.mark.asyncio
+async def test_create_chat_maps_api_error() -> None:
+    """create_chat surfaces BlueBubbles JSON errors as HomeAssistantError."""
+
+    class FakeResponse:
+        status = 200
+
+        async def text(self):
+            return json.dumps(
+                {
+                    "status": 500,
+                    "message": "Failed to send",
+                    "error": {"message": "Private API is not enabled"},
+                }
+            )
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeSession:
+        def post(self, *args, **kwargs):
+            return FakeResponse()
+
+    api = BlueBubblesApi(
+        "http://bb.local:1234",
+        "secret-password",
+        False,
+        FakeSession(),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(HomeAssistantError, match="Private API is not enabled") as err:
+        await api.async_create_chat(["+15551234567"], message="hi")
+
+    assert not isinstance(err.value, aiohttp.ClientError)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,85 @@
+"""Tests for the BlueBubbles config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.bluebubbles.const import CONF_PASSWORD, CONF_SSL, DOMAIN
+
+MOCK_HOST = "http://127.0.0.1:1234"
+MOCK_PASSWORD = "test-password"
+
+
+async def test_user_flow_success(hass: HomeAssistant, aioclient_mock) -> None:
+    """Test a successful config flow."""
+    aioclient_mock.get(
+        f"{MOCK_HOST}/api/v1/server/info",
+        json={
+            "status": 200,
+            "message": "Success",
+            "data": {
+                "private_api": True,
+                "detected_imessage": "user@icloud.com",
+            },
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {}
+
+    with patch.object(
+        hass.config_entries,
+        "async_setup",
+        new=AsyncMock(return_value=True),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: MOCK_HOST,
+                CONF_PASSWORD: MOCK_PASSWORD,
+                CONF_SSL: False,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "user@icloud.com"
+    assert result["data"][CONF_HOST] == MOCK_HOST
+    assert result["data"][CONF_PASSWORD] == MOCK_PASSWORD
+    assert result["data"]["private_api"] is True
+
+
+async def test_user_flow_cannot_connect(hass: HomeAssistant, aioclient_mock) -> None:
+    """Test config flow failure when BlueBubbles returns an API error."""
+    aioclient_mock.get(
+        f"{MOCK_HOST}/api/v1/server/info",
+        status=401,
+        json={
+            "status": 401,
+            "message": "Unauthorized",
+            "error": {"message": "Invalid password"},
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: MOCK_HOST,
+            CONF_PASSWORD: MOCK_PASSWORD,
+            CONF_SSL: False,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"]["base"] == "cannot_connect"

--- a/tests/test_send_message.py
+++ b/tests/test_send_message.py
@@ -1,0 +1,154 @@
+"""Tests for bluebubbles.send_message service paths."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bluebubbles.const import CONF_HOST, CONF_PASSWORD, CONF_SSL, DOMAIN
+
+MOCK_HOST = "http://127.0.0.1:1234"
+MOCK_PASSWORD = "test-password"
+
+
+def _mock_entry() -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_PASSWORD: MOCK_PASSWORD,
+            CONF_SSL: False,
+            "private_api": True,
+        },
+        title="user@icloud.com",
+    )
+
+
+async def _setup_integration(hass: HomeAssistant, aioclient_mock) -> MockConfigEntry:
+    aioclient_mock.get(
+        f"{MOCK_HOST}/api/v1/server/info",
+        json={
+            "status": 200,
+            "message": "Success",
+            "data": {"private_api": True, "detected_imessage": "user@icloud.com"},
+        },
+    )
+    entry = _mock_entry()
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_send_message_maps_api_error_to_homeassistant_error(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """Users should see the BlueBubbles error text, not a bare ClientError."""
+    await _setup_integration(hass, aioclient_mock)
+    aioclient_mock.post(
+        f"{MOCK_HOST}/api/v1/chat/new",
+        status=400,
+        json={
+            "status": 400,
+            "message": "You've made a bad request!",
+            "error": {"message": "Handle is not registered with iMessage"},
+        },
+    )
+
+    with pytest.raises(HomeAssistantError, match="Handle is not registered with iMessage") as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "send_message",
+            {"addresses": "+15551234567", "message": "hello"},
+            blocking=True,
+        )
+
+    assert "Unknown error" not in str(err.value)
+
+
+async def test_send_message_attachment_happy_path(
+    hass: HomeAssistant, aioclient_mock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Attachment path is uploaded after chat creation."""
+    await _setup_integration(hass, aioclient_mock)
+
+    image_path = tmp_path / "snapshot.jpg"
+    image_path.write_bytes(b"fake-image-bytes")
+
+    monkeypatch.setattr(hass.config, "is_allowed_path", lambda path: True)
+
+    aioclient_mock.post(
+        f"{MOCK_HOST}/api/v1/chat/new",
+        json={
+            "status": 200,
+            "message": "Successfully created chat!",
+            "data": {"guid": "iMessage;-;+15551234567"},
+        },
+    )
+    aioclient_mock.post(
+        f"{MOCK_HOST}/api/v1/message/attachment",
+        json={
+            "status": 200,
+            "message": "Successfully sent attachment!",
+            "data": {"guid": "message-guid"},
+        },
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "send_message",
+        {
+            "addresses": "+15551234567",
+            "message": "Front door",
+            "attachment": str(image_path),
+        },
+        blocking=True,
+    )
+
+    # mock_calls entries are (method, url, data, headers); urls may include query params
+    paths = [req[1].path for req in aioclient_mock.mock_calls]
+    assert "/api/v1/chat/new" in paths
+    assert "/api/v1/message/attachment" in paths
+
+
+async def test_send_message_media_url_happy_path(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """media_url is downloaded and sent as an attachment."""
+    await _setup_integration(hass, aioclient_mock)
+
+    aioclient_mock.post(
+        f"{MOCK_HOST}/api/v1/chat/new",
+        json={
+            "status": 200,
+            "message": "Successfully created chat!",
+            "data": {"guid": "iMessage;-;+15551234567"},
+        },
+    )
+    aioclient_mock.get(
+        "http://127.0.0.1/local/snap.jpg",
+        content=b"remote-image",
+        headers={"Content-Type": "image/jpeg"},
+    )
+    aioclient_mock.post(
+        f"{MOCK_HOST}/api/v1/message/attachment",
+        json={
+            "status": 200,
+            "message": "Successfully sent attachment!",
+            "data": {"guid": "message-guid"},
+        },
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "send_message",
+        {
+            "addresses": "+15551234567",
+            "media_url": "http://127.0.0.1/local/snap.jpg",
+        },
+        blocking=True,
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the pain points from [#2](https://github.com/helv-io/ha-bluebubbles/issues/2): send failures showed generic “Unknown error”, and there was no first-class way to attach images.

- **Actionable errors**: BlueBubbles JSON `error` / `message` (plus HTTP status context) are mapped to `HomeAssistantError`, so service calls show the real API reason instead of a bare `ClientError`.
- **Safe logging**: Response bodies are logged with passwords/tokens redacted.
- **Attachments**: Optional `attachment` (local path under `allowlist_external_dirs`) and `media_url` on `bluebubbles.send_message`, wired through `/api/v1/chat/new` + `/api/v1/message/attachment`.
- **Dependency pin**: `aiohttp>=3.9.0,<4.0.0` in `manifest.json`.
- **Tests + CI**: Pytest suite with mocked aiohttp covering config flow, error mapping (asserts meaningful `HomeAssistantError`), and attachment/`media_url` happy paths. Adds a lightweight `.github/workflows/test.yml` alongside existing hassfest/HACS jobs.

Uses Home Assistant’s shared `async_get_clientsession` instead of ad-hoc `ClientSession`s.

**Out of scope / follow-up:** inbound messaging / device triggers (issue #4) — next up after this.

## Test plan

- [x] `pytest -q` locally (11 passed)
- [ ] hassfest + HACS workflows green on the PR
- [ ] Manual: call `bluebubbles.send_message` with an invalid recipient and confirm HA shows the BlueBubbles error text (not “Unknown error”)
- [ ] Manual: send an image via `attachment: /config/www/snapshot.jpg` (with `allowlist_external_dirs`) and confirm delivery
- [ ] Manual: optional `media_url` download/attach path
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6519281d-184e-49f7-a44b-34482dde7035?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6519281d-184e-49f7-a44b-34482dde7035&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

