### PR TITLE
Polish 0.5: Dependabot, diagnostics redaction, docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Send and receive iMessage/RCS/SMS/MMS from Home Assistant via a [BlueBubbles](ht
 
 Existing installs that only send messages keep working with no reconfigure — inbound is opt-in under **Configure**.
 
+## Upgrading to 0.5
+
+0.5 is additive. After updating (HACS/restart):
+
+1. Send-only setups need no changes.
+2. To receive messages, open **Configure**, enable inbound webhooks, and save (a stable webhook id is created for you).
+3. Use the BlueBubbles device triggers — see [Device triggers](#device-triggers) and [Example automations](#example-automations).
+
 ## Installation
 
 ### HACS (Recommended)
@@ -54,12 +62,12 @@ The integration automatically detects if Private API is enabled on your server a
 
 ## Inbound messages & device triggers
 
-Inbound messaging is **opt-in** so existing send-only setups are unchanged.
+Inbound messaging is **opt-in** so existing send-only setups are unchanged. Jump to [Example automations](#example-automations) for copy-paste YAML.
 
 1. Open **Settings → Devices & Services → BlueBubbles → Configure**.
 2. Enable **Enable inbound message webhooks**.
 3. Leave **Auto-register webhook with BlueBubbles server** on if Home Assistant has a URL the Mac can reach (same LAN is fine, e.g. `http://homeassistant.local:8123`).
-4. Save. The options form shows the webhook path (for example `/api/webhook/<id>`).
+4. Save. The options form shows the webhook path (for example `/api/webhook/<id>`). Saving Configure always persists a stable `webhook_id` (no ephemeral webhook for normal UX).
 
 ### Network notes
 

--- a/custom_components/bluebubbles/diagnostics.py
+++ b/custom_components/bluebubbles/diagnostics.py
@@ -1,0 +1,56 @@
+"""Diagnostics support for BlueBubbles."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components import webhook
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.loader import async_get_integration
+
+from .const import (
+    CONF_ENABLE_INBOUND,
+    CONF_PASSWORD,
+    CONF_WEBHOOK_ID,
+    DEFAULT_ENABLE_INBOUND,
+    DOMAIN,
+)
+
+TO_REDACT = {CONF_PASSWORD}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry.
+
+    Includes host and options flags, but never the BlueBubbles password.
+    Webhook identity is exposed as the relative path only (not the raw id).
+    """
+    integration = await async_get_integration(hass, DOMAIN)
+    options = dict(entry.options)
+    webhook_id = options.get(CONF_WEBHOOK_ID)
+    webhook_path = (
+        webhook.async_generate_path(webhook_id) if webhook_id else None
+    )
+
+    # Drop the raw webhook_id; the path is enough for support without the secret.
+    safe_options = {
+        key: value for key, value in options.items() if key != CONF_WEBHOOK_ID
+    }
+
+    return {
+        "config_entry": {
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": safe_options,
+        },
+        "inbound_enabled": bool(
+            options.get(CONF_ENABLE_INBOUND, DEFAULT_ENABLE_INBOUND)
+        ),
+        "webhook_path": webhook_path,
+        "private_api": entry.data.get("private_api"),
+        "integration_version": str(integration.version),
+    }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ha-bluebubbles",
-  "version": "0.3.5",
+  "version": "0.5.0",
   "description": "A project for managing BlueBubbles integration.",
   "author": "Helvio Pedreschi",
   "license": "MIT",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,81 @@
+"""Tests for BlueBubbles diagnostics redaction."""
+
+from __future__ import annotations
+
+import json
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bluebubbles.const import (
+    CONF_ENABLE_INBOUND,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SSL,
+    CONF_WEBHOOK_ID,
+    DOMAIN,
+)
+from custom_components.bluebubbles.diagnostics import (
+    TO_REDACT,
+    async_get_config_entry_diagnostics,
+)
+
+MOCK_HOST = "http://127.0.0.1:1234"
+MOCK_PASSWORD = "super-secret-bb-password"
+WEBHOOK_ID = "diag-webhook-id"
+
+
+async def test_diagnostics_redacts_password(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """Diagnostics include host/flags/path/version but never the password."""
+    aioclient_mock.get(
+        f"{MOCK_HOST}/api/v1/server/info",
+        json={
+            "status": 200,
+            "data": {"private_api": True, "detected_imessage": "user@icloud.com"},
+        },
+    )
+    assert await async_setup_component(hass, "diagnostics", {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_PASSWORD: MOCK_PASSWORD,
+            CONF_SSL: False,
+            "private_api": True,
+        },
+        options={
+            CONF_ENABLE_INBOUND: True,
+            CONF_WEBHOOK_ID: WEBHOOK_ID,
+            "auto_register_webhook": False,
+            "webhook_local_only": True,
+            "include_from_me": False,
+            "allowed_handles": "",
+        },
+        title="user@icloud.com",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["inbound_enabled"] is True
+    assert result["webhook_path"] == f"/api/webhook/{WEBHOOK_ID}"
+    assert result["private_api"] is True
+    assert result["integration_version"] == "0.5.0"
+
+    config_data = result["config_entry"]["data"]
+    assert config_data[CONF_HOST] == MOCK_HOST
+    assert config_data[CONF_PASSWORD] == async_redact_data(
+        {CONF_PASSWORD: MOCK_PASSWORD}, TO_REDACT
+    )[CONF_PASSWORD]
+    assert CONF_WEBHOOK_ID not in result["config_entry"]["options"]
+
+    serialized = json.dumps(result)
+    assert MOCK_PASSWORD not in serialized
+    assert "password" in serialized  # key present, value redacted

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -52,3 +52,19 @@ async def test_options_flow_enables_inbound(hass: HomeAssistant) -> None:
     assert entry.options[CONF_ENABLE_INBOUND] is True
     assert entry.options[CONF_WEBHOOK_ID]
     assert entry.options["allowed_handles"] == "+15551234567"
+
+    # Re-saving options must keep the same webhook_id (stable, not ephemeral).
+    first_webhook_id = entry.options[CONF_WEBHOOK_ID]
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_ENABLE_INBOUND: True,
+            "auto_register_webhook": False,
+            "webhook_local_only": True,
+            "include_from_me": False,
+            "allowed_handles": "+15551234567",
+        },
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_WEBHOOK_ID] == first_webhook_id


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Post-0.5 polish pass only — no new major features, no breaking changes to services, config entry data, or default options. Main already includes v0.5.0 (errors/attachments + inbound device triggers).

### Changes
- **Dependabot**: weekly updates for `github-actions` and `pip` (`.github/dependabot.yml`)
- **Diagnostics**: `async_get_config_entry_diagnostics` returns host, inbound enabled, webhook **path** (not raw id), `private_api`, and integration version; password is always redacted via HA `async_redact_data`
- **Docs**: short “Upgrading to 0.5” note + clearer links to device triggers / example automations; notes that Configure persists a stable `webhook_id`
- **Tooling**: align `package.json` version with manifest `0.5.0` for existing release-it bumper flow (`hacs.json` unchanged)
- **Tests**: diagnostics password redaction + options-flow webhook_id stability across re-save

### Verified already present (no code change needed)
- Invalid regex in phrase triggers is safe (`re.error` → no match; covered by unit test)
- Options flow creates/persists a stable `webhook_id` when enabling inbound (ephemeral path remains a safety net only)
- Inactive hassfest/HACS workflows already removed and superseded by `Validate`

### Version
Kept at **0.5.0** — tooling/docs/diagnostics support polish only; no user-visible behavioral fixes that warrant 0.5.1.

## Test plan
- [x] `pytest -q` locally (26 passed)
- [ ] CI: Pytest + Hassfest + HACS green on this PR
- [ ] Manual smoke (optional): Download diagnostics from the BlueBubbles config entry and confirm password is `**REDACTED**` while host/webhook path/version are present

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-711c1181-6ecf-42aa-8e51-f379ebff2b67?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-711c1181-6ecf-42aa-8e51-f379ebff2b67&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

