### PR TITLE
fix: discoverable BlueBubbles triggers (0.6.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: "3.14"
       - name: Install test dependencies
         run: pip install -r requirements_test.txt
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ Send and receive iMessage/RCS/SMS/MMS from Home Assistant via a [BlueBubbles](ht
 
 - **Outbound**: `bluebubbles.send_message` talks to the BlueBubbles REST API (`/api/v1/chat/new`, `/api/v1/message/attachment`) through a shared `aiohttp` session (`async_get_clientsession`).
 - **Inbound** (optional): Home Assistant registers a webhook (`/api/webhook/<id>`). BlueBubbles POSTs `new-message` events to it (auto-registered via `/api/v1/webhook` when enabled, or manually in the BlueBubbles UI).
-- **Automations**: A BlueBubbles device exposes device triggers `message_received` and `phrase_received`, backed by the `bluebubbles_message_received` event.
+- **Automations**: Integration triggers (`bluebubbles.message_received` / `bluebubbles.phrase_received`) and device triggers on the BlueBubbles device, all backed by the `bluebubbles_message_received` event. An `event.bluebubbles_message` entity also fires for Developer Tools / state-style triggers.
 
 Existing installs that only send messages keep working with no reconfigure — inbound is opt-in under **Configure**.
 
-## Upgrading to 0.5
+## Upgrading to 0.6.0
 
-0.5 is additive. After updating (HACS/restart):
+0.6.0 is additive (no re-add required). After updating via HACS and reloading/restarting:
 
 1. Send-only setups need no changes.
-2. To receive messages, open **Configure**, enable inbound webhooks, and save (a stable webhook id is created for you).
-3. Use the BlueBubbles device triggers — see [Device triggers](#device-triggers) and [Example automations](#example-automations).
+2. Triggers are discoverable by name: **Settings → Automations → Add trigger → search “BlueBubbles”**.
+3. Or use **Device → BlueBubbles → Message received / Phrase received**.
+4. To receive messages, open **Configure**, enable inbound webhooks, and save (a stable webhook id is created for you). Triggers stay visible even when inbound is off; they simply will not fire until inbound is enabled.
 
 ## Installation
 
@@ -60,7 +61,7 @@ This integration uses Home Assistant's configuration flow for setup. BlueBubbles
 
 The integration automatically detects if Private API is enabled on your server and updates this on Home Assistant restarts. Private API is required for sending to multiple addresses (group messages); without it, only single-address sends are supported.
 
-## Inbound messages & device triggers
+## Inbound messages & triggers
 
 Inbound messaging is **opt-in** so existing send-only setups are unchanged. Jump to [Example automations](#example-automations) for copy-paste YAML.
 
@@ -68,6 +69,15 @@ Inbound messaging is **opt-in** so existing send-only setups are unchanged. Jump
 2. Enable **Enable inbound message webhooks**.
 3. Leave **Auto-register webhook with BlueBubbles server** on if Home Assistant has a URL the Mac can reach (same LAN is fine, e.g. `http://homeassistant.local:8123`).
 4. Save. The options form shows the webhook path (for example `/api/webhook/<id>`). Saving Configure always persists a stable `webhook_id` (no ephemeral webhook for normal UX).
+
+### Finding triggers in the UI
+
+BlueBubbles does **not** appear as a top-level “trigger type” in older menus the way sun/time do on every screen. Use one of these paths:
+
+1. **Recommended:** **Settings → Automations & Scenes → Create automation → Add trigger → search “BlueBubbles”** → choose **Message received** or **Phrase received**.
+2. **Device path:** **Add trigger → Device → select your BlueBubbles device → Message received / Phrase received**.
+
+Triggers are registered even when inbound is disabled; they will not fire until inbound webhooks are enabled and BlueBubbles is posting `new-message` events.
 
 ### Network notes
 
@@ -78,9 +88,7 @@ Inbound messaging is **opt-in** so existing send-only setups are unchanged. Jump
   - Events: `new-message`
 - BlueBubbles server **1.0.0+** is required for webhooks.
 
-### Device triggers
-
-On the BlueBubbles device, automations can use:
+### Trigger types
 
 | Trigger | When it fires |
 |---|---|
@@ -89,6 +97,8 @@ On the BlueBubbles device, automations can use:
 
 Trigger data available in templates includes: `trigger.text`, `trigger.sender`, `trigger.sender_name`, `trigger.chat_guid`, `trigger.chat_identifier`, `trigger.message_guid`, `trigger.attachments`, `trigger.timestamp`, `trigger.service`, and for phrase triggers `trigger.matched_phrase`.
 
+The integration also creates **`event.<name>_message`** (translation: Message). It fires on inbound messages with the same attributes, so you can inspect the latest message in Developer Tools → States, or use a generic event-entity trigger.
+
 Optional Configure filters:
 
 - **Allowed senders** — comma-separated phones/emails; empty means all
@@ -96,16 +106,13 @@ Optional Configure filters:
 
 ### Example automations
 
-Any inbound message → notify:
+Any inbound message → notify (integration trigger):
 
 ```yaml
 automation:
   - alias: iMessage received
     trigger:
-      - platform: device
-        domain: bluebubbles
-        device_id: YOUR_BLUEBUBBLES_DEVICE_ID
-        type: message_received
+      - platform: bluebubbles.message_received
     action:
       - service: notify.persistent_notification
         data:
@@ -119,17 +126,32 @@ Phrase match → run a script:
 automation:
   - alias: Text "Send Me The Bill"
     trigger:
-      - platform: device
-        domain: bluebubbles
-        device_id: YOUR_BLUEBUBBLES_DEVICE_ID
-        type: phrase_received
-        phrase: "Send Me The Bill"
-        match_type: contains
+      - platform: bluebubbles.phrase_received
+        options:
+          phrase: "Send Me The Bill"
+          match_type: contains
     action:
       - service: script.send_latest_bill
 ```
 
-You can also listen for the raw event:
+Device trigger form (same events):
+
+```yaml
+automation:
+  - alias: iMessage received (device)
+    trigger:
+      - platform: device
+        domain: bluebubbles
+        device_id: YOUR_BLUEBUBBLES_DEVICE_ID
+        type: message_received
+    action:
+      - service: notify.persistent_notification
+        data:
+          title: "iMessage from {{ trigger.sender }}"
+          message: "{{ trigger.text }}"
+```
+
+You can also listen for the raw bus event:
 
 ```yaml
 trigger:
@@ -207,7 +229,8 @@ You can also call this service from the Developer Tools > Services page for test
 - **Attachment Path Blocked**: If sending an image fails with an allowlist error, add the directory to `allowlist_external_dirs` and restart Home Assistant.
 - **Group Send Failures**: If sending to multiple addresses fails, ensure Private API is enabled on your BlueBubbles server (check server settings). The integration detects this automatically on setup and restarts.
 - **SSL Problems**: If using HTTPS, try toggling the SSL option.
-- **Inbound not firing**: Confirm inbound is enabled under Configure, BlueBubbles has a `new-message` webhook pointing at Home Assistant, and (if using local-only) the Mac is on the same network. Check logs for `bluebubbles` webhook registration lines.
+- **Can't find BlueBubbles triggers**: Update to **0.6.0** via HACS and reload. Then use **Automations → Add trigger → search BlueBubbles**, or **Device → BlueBubbles → Message received**. Device triggers are not listed under a separate “BlueBubbles” category outside the device picker.
+- **Inbound not firing**: Confirm inbound is enabled under Configure, BlueBubbles has a `new-message` webhook pointing at Home Assistant, and (if using local-only) the Mac is on the same network. Check logs for `bluebubbles` webhook registration lines. Triggers can still be selected when inbound is off; they only fire after inbound is enabled.
 - For other issues, check the Home Assistant logs (search for "bluebubbles") or open an [issue][issue-tracker].
 
 ## Contributing

--- a/custom_components/bluebubbles/__init__.py
+++ b/custom_components/bluebubbles/__init__.py
@@ -22,9 +22,10 @@ from .inbound import InboundManager
 
 _LOGGER = logging.getLogger(__name__)
 
-# No entity platforms; device_trigger.py is discovered via the device automation
-# integration when automations reference this domain's devices.
-PLATFORMS: list[Platform] = []
+# Event entity surfaces inbound messages in Developer Tools / state triggers.
+# device_trigger.py and trigger.py are discovered via device automation / the
+# trigger helper (not listed here).
+PLATFORMS: list[Platform] = [Platform.EVENT]
 
 
 @dataclass
@@ -173,6 +174,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not hass.services.has_service(DOMAIN, "send_message"):
         hass.services.async_register(DOMAIN, "send_message", send_message)
 
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
 
@@ -184,6 +186,10 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry and tear down inbound listeners/webhooks."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if not unload_ok:
+        return False
+
     runtime: BlueBubblesRuntimeData | dict[str, Any] | None = hass.data.get(
         DOMAIN, {}
     ).pop(entry.entry_id, None)

--- a/custom_components/bluebubbles/device_trigger.py
+++ b/custom_components/bluebubbles/device_trigger.py
@@ -2,20 +2,20 @@
 
 from __future__ import annotations
 
-import logging
-import re
+import asyncio
 from typing import Any
 
 import voluptuous as vol
 
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_DOMAIN,
     CONF_PLATFORM,
     CONF_TYPE,
 )
-from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
@@ -26,17 +26,15 @@ from .const import (
     DOMAIN,
     EVENT_MESSAGE_RECEIVED,
     MATCH_TYPE_CONTAINS,
-    MATCH_TYPE_EXACT,
-    MATCH_TYPE_REGEX,
     MATCH_TYPES,
     TRIGGER_TYPE_MESSAGE_RECEIVED,
     TRIGGER_TYPE_PHRASE_RECEIVED,
 )
-
-_LOGGER = logging.getLogger(__name__)
+from .matching import phrase_matches
 
 TRIGGER_TYPES = {TRIGGER_TYPE_MESSAGE_RECEIVED, TRIGGER_TYPE_PHRASE_RECEIVED}
 
+# Module-level constant required by device automation discovery.
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
@@ -51,10 +49,21 @@ def _is_bluebubbles_device(device: dr.DeviceEntry) -> bool:
     return any(identifier[0] == DOMAIN for identifier in device.identifiers)
 
 
+async def async_validate_trigger_config(
+    hass: HomeAssistant, config: ConfigType
+) -> ConfigType:
+    """Validate a device trigger config."""
+    return TRIGGER_SCHEMA(config)
+
+
 async def async_get_triggers(
     hass: HomeAssistant, device_id: str
 ) -> list[dict[str, str]]:
-    """Return device triggers for BlueBubbles devices."""
+    """Return device triggers for BlueBubbles devices.
+
+    Triggers are always listed when the BlueBubbles device exists. They simply
+    will not fire until inbound messaging is enabled under Configure.
+    """
     device_registry = dr.async_get(hass)
     device = device_registry.async_get(device_id)
     if device is None or not _is_bluebubbles_device(device):
@@ -95,23 +104,40 @@ async def async_get_trigger_capabilities(
     }
 
 
-def _phrase_matches(text: str, phrase: str, match_type: str) -> bool:
-    """Return True if text matches phrase using the selected strategy."""
-    if not phrase:
-        return False
-
-    if match_type == MATCH_TYPE_EXACT:
-        return text.strip().lower() == phrase.strip().lower()
-
-    if match_type == MATCH_TYPE_REGEX:
-        try:
-            return re.search(phrase, text, re.IGNORECASE) is not None
-        except re.error:
-            _LOGGER.warning("Invalid regex in BlueBubbles phrase trigger: %s", phrase)
-            return False
-
-    # Default: case-insensitive contains
-    return phrase.lower() in text.lower()
+def _enrich_trigger_payload(
+    *,
+    trigger: dict[str, Any],
+    trigger_type: str,
+    device_id: str,
+    event_data: dict[str, Any],
+    phrase: str,
+    match_type: str,
+) -> dict[str, Any]:
+    """Build the flattened device-trigger payload used by templates."""
+    text = str(event_data.get("text") or "")
+    payload: dict[str, Any] = {
+        **trigger,
+        "platform": "device",
+        "domain": DOMAIN,
+        "type": trigger_type,
+        "device_id": device_id,
+        "text": text,
+        "message": text,
+        "sender": event_data.get("sender", ""),
+        "sender_name": event_data.get("sender_name", ""),
+        "chat_guid": event_data.get("chat_guid", ""),
+        "chat_identifier": event_data.get("chat_identifier", ""),
+        "message_guid": event_data.get("message_guid", ""),
+        "is_from_me": event_data.get("is_from_me", False),
+        "timestamp": event_data.get("timestamp"),
+        "attachments": event_data.get("attachments") or [],
+        "service": event_data.get("service", ""),
+        "subject": event_data.get("subject", ""),
+    }
+    if trigger_type == TRIGGER_TYPE_PHRASE_RECEIVED:
+        payload["matched_phrase"] = phrase
+        payload["match_type"] = match_type
+    return payload
 
 
 async def async_attach_trigger(
@@ -120,49 +146,55 @@ async def async_attach_trigger(
     action: TriggerActionType,
     trigger_info: TriggerInfo,
 ) -> CALLBACK_TYPE:
-    """Attach a device trigger to the inbound message event."""
+    """Attach a device trigger via the core event trigger helper."""
+    config = TRIGGER_SCHEMA(config)
     trigger_type = config[CONF_TYPE]
     device_id = config[CONF_DEVICE_ID]
     phrase = str(config.get(CONF_PHRASE) or "")
     match_type = config.get(CONF_MATCH_TYPE, MATCH_TYPE_CONTAINS)
-    job = HassJob(action, f"BlueBubbles device trigger {trigger_type}")
 
-    @callback
-    def _handle_event(event) -> None:
-        """Filter inbound events and run the automation action."""
-        event_data: dict[str, Any] = event.data
-        if event_data.get("device_id") != device_id:
-            return
-
-        text = str(event_data.get("text") or "")
-        if trigger_type == TRIGGER_TYPE_PHRASE_RECEIVED:
-            if not _phrase_matches(text, phrase, match_type):
-                return
-
-        trigger_payload: dict[str, Any] = {
-            **trigger_info["trigger_data"],
-            "platform": "device",
-            "domain": DOMAIN,
-            "type": trigger_type,
-            "device_id": device_id,
-            "text": text,
-            "message": text,
-            "sender": event_data.get("sender", ""),
-            "sender_name": event_data.get("sender_name", ""),
-            "chat_guid": event_data.get("chat_guid", ""),
-            "chat_identifier": event_data.get("chat_identifier", ""),
-            "message_guid": event_data.get("message_guid", ""),
-            "is_from_me": event_data.get("is_from_me", False),
-            "timestamp": event_data.get("timestamp"),
-            "attachments": event_data.get("attachments") or [],
-            "service": event_data.get("service", ""),
-            "subject": event_data.get("subject", ""),
-            "event": event,
+    event_config = event_trigger.TRIGGER_SCHEMA(
+        {
+            event_trigger.CONF_PLATFORM: "event",
+            event_trigger.CONF_EVENT_TYPE: EVENT_MESSAGE_RECEIVED,
+            event_trigger.CONF_EVENT_DATA: {CONF_DEVICE_ID: device_id},
         }
+    )
+
+    async def _wrapped_action(
+        run_variables: dict[str, Any], context: Context | None = None
+    ) -> Any:
+        """Filter phrase matches and flatten event fields onto trigger."""
+        trigger = dict(run_variables.get("trigger") or {})
+        event = trigger.get("event")
+        event_data: dict[str, Any] = dict(event.data) if event is not None else {}
+        text = str(event_data.get("text") or "")
+
         if trigger_type == TRIGGER_TYPE_PHRASE_RECEIVED:
-            trigger_payload["matched_phrase"] = phrase
-            trigger_payload["match_type"] = match_type
+            if not phrase_matches(text, phrase, match_type):
+                return None
 
-        hass.async_run_hass_job(job, {"trigger": trigger_payload})
+        enriched = _enrich_trigger_payload(
+            trigger=trigger,
+            trigger_type=trigger_type,
+            device_id=device_id,
+            event_data=event_data,
+            phrase=phrase,
+            match_type=match_type,
+        )
+        result = action({"trigger": enriched}, context)
+        if asyncio.iscoroutine(result):
+            return await result
+        return result
 
-    return hass.bus.async_listen(EVENT_MESSAGE_RECEIVED, _handle_event)
+    return await event_trigger.async_attach_trigger(
+        hass,
+        event_config,
+        _wrapped_action,
+        trigger_info,
+        platform_type="device",
+    )
+
+
+# Backwards-compatible alias for unit tests that imported the private helper.
+_phrase_matches = phrase_matches

--- a/custom_components/bluebubbles/event.py
+++ b/custom_components/bluebubbles/event.py
@@ -1,0 +1,80 @@
+"""Event platform for BlueBubbles inbound messages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.event import EventEntity, EventEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, EVENT_MESSAGE_RECEIVED, TRIGGER_TYPE_MESSAGE_RECEIVED
+
+ENTITY_DESCRIPTION = EventEntityDescription(
+    key="message",
+    translation_key="message",
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the BlueBubbles event entity."""
+    runtime = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [BlueBubblesMessageEventEntity(entry, device_id=runtime.device_id)]
+    )
+
+
+class BlueBubblesMessageEventEntity(EventEntity):
+    """Event entity that fires when an inbound BlueBubbles message arrives."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    entity_description = ENTITY_DESCRIPTION
+
+    def __init__(self, entry: ConfigEntry, *, device_id: str) -> None:
+        """Initialize the event entity."""
+        self._entry = entry
+        self._device_id = device_id
+        self._attr_unique_id = f"{entry.entry_id}_message"
+        self._attr_event_types = [TRIGGER_TYPE_MESSAGE_RECEIVED]
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to inbound message events."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.hass.bus.async_listen(
+                EVENT_MESSAGE_RECEIVED, self._async_handle_bus_event
+            )
+        )
+
+    @callback
+    def _async_handle_bus_event(self, event) -> None:
+        """Handle a bluebubbles_message_received bus event."""
+        data: dict[str, Any] = dict(event.data)
+        if data.get("device_id") != self._device_id:
+            return
+
+        attributes = {
+            "text": data.get("text", ""),
+            "sender": data.get("sender", ""),
+            "sender_name": data.get("sender_name", ""),
+            "chat_guid": data.get("chat_guid", ""),
+            "chat_identifier": data.get("chat_identifier", ""),
+            "message_guid": data.get("message_guid", ""),
+            "is_from_me": data.get("is_from_me", False),
+            "timestamp": data.get("timestamp"),
+            "attachments": data.get("attachments") or [],
+            "service": data.get("service", ""),
+            "subject": data.get("subject", ""),
+        }
+        self._trigger_event(TRIGGER_TYPE_MESSAGE_RECEIVED, attributes)
+        self.async_write_ha_state()

--- a/custom_components/bluebubbles/manifest.json
+++ b/custom_components/bluebubbles/manifest.json
@@ -16,5 +16,5 @@
     "aiohttp>=3.9.0,<4.0.0"
   ],
   "single_config_entry": true,
-  "version": "0.5.0"
+  "version": "0.6.0"
 }

--- a/custom_components/bluebubbles/matching.py
+++ b/custom_components/bluebubbles/matching.py
@@ -1,0 +1,29 @@
+"""Shared phrase-matching helpers for BlueBubbles triggers."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from .const import MATCH_TYPE_EXACT, MATCH_TYPE_REGEX
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def phrase_matches(text: str, phrase: str, match_type: str) -> bool:
+    """Return True if text matches phrase using the selected strategy."""
+    if not phrase:
+        return False
+
+    if match_type == MATCH_TYPE_EXACT:
+        return text.strip().lower() == phrase.strip().lower()
+
+    if match_type == MATCH_TYPE_REGEX:
+        try:
+            return re.search(phrase, text, re.IGNORECASE) is not None
+        except re.error:
+            _LOGGER.warning("Invalid regex in BlueBubbles phrase trigger: %s", phrase)
+            return False
+
+    # Default: case-insensitive contains
+    return phrase.lower() in text.lower()

--- a/custom_components/bluebubbles/strings.json
+++ b/custom_components/bluebubbles/strings.json
@@ -31,7 +31,7 @@
           "allowed_handles": "Allowed senders (optional, comma-separated phones/emails; empty = all)"
         },
         "data_description": {
-          "enable_inbound": "Registers a Home Assistant webhook and fires device triggers for new messages.",
+          "enable_inbound": "Registers a Home Assistant webhook and fires BlueBubbles triggers for new messages. Triggers stay visible even when this is off; they simply will not fire until inbound is enabled.",
           "auto_register_webhook": "Calls the BlueBubbles /api/v1/webhook API using your Home Assistant URL.",
           "webhook_local_only": "Recommended when BlueBubbles and Home Assistant share a LAN.",
           "include_from_me": "Off by default so your own outbound messages do not fire automations.",
@@ -40,10 +40,59 @@
       }
     }
   },
+  "entity": {
+    "event": {
+      "message": {
+        "name": "Message",
+        "state_attributes": {
+          "text": { "name": "Text" },
+          "sender": { "name": "Sender" },
+          "sender_name": { "name": "Sender name" },
+          "chat_guid": { "name": "Chat GUID" },
+          "chat_identifier": { "name": "Chat identifier" },
+          "message_guid": { "name": "Message GUID" },
+          "is_from_me": { "name": "From me" },
+          "timestamp": { "name": "Timestamp" },
+          "attachments": { "name": "Attachments" },
+          "service": { "name": "Service" },
+          "subject": { "name": "Subject" }
+        }
+      }
+    }
+  },
   "device_automation": {
     "trigger_type": {
       "message_received": "Message received",
       "phrase_received": "Phrase received"
+    }
+  },
+  "selector": {
+    "match_type": {
+      "options": {
+        "contains": "Contains",
+        "exact": "Exact",
+        "regex": "Regular expression"
+      }
+    }
+  },
+  "triggers": {
+    "message_received": {
+      "name": "Message received",
+      "description": "Triggers when one or more BlueBubbles messages are received."
+    },
+    "phrase_received": {
+      "name": "Phrase received",
+      "description": "Triggers when one or more BlueBubbles messages match a phrase.",
+      "fields": {
+        "phrase": {
+          "name": "Phrase",
+          "description": "Text to match against the inbound message body."
+        },
+        "match_type": {
+          "name": "Match type",
+          "description": "How the phrase is compared to the message text."
+        }
+      }
     }
   }
 }

--- a/custom_components/bluebubbles/translations/en.json
+++ b/custom_components/bluebubbles/translations/en.json
@@ -31,7 +31,7 @@
           "allowed_handles": "Allowed senders (optional, comma-separated phones/emails; empty = all)"
         },
         "data_description": {
-          "enable_inbound": "Registers a Home Assistant webhook and fires device triggers for new messages.",
+          "enable_inbound": "Registers a Home Assistant webhook and fires BlueBubbles triggers for new messages. Triggers stay visible even when this is off; they simply will not fire until inbound is enabled.",
           "auto_register_webhook": "Calls the BlueBubbles /api/v1/webhook API using your Home Assistant URL.",
           "webhook_local_only": "Recommended when BlueBubbles and Home Assistant share a LAN.",
           "include_from_me": "Off by default so your own outbound messages do not fire automations.",
@@ -40,10 +40,59 @@
       }
     }
   },
+  "entity": {
+    "event": {
+      "message": {
+        "name": "Message",
+        "state_attributes": {
+          "text": { "name": "Text" },
+          "sender": { "name": "Sender" },
+          "sender_name": { "name": "Sender name" },
+          "chat_guid": { "name": "Chat GUID" },
+          "chat_identifier": { "name": "Chat identifier" },
+          "message_guid": { "name": "Message GUID" },
+          "is_from_me": { "name": "From me" },
+          "timestamp": { "name": "Timestamp" },
+          "attachments": { "name": "Attachments" },
+          "service": { "name": "Service" },
+          "subject": { "name": "Subject" }
+        }
+      }
+    }
+  },
   "device_automation": {
     "trigger_type": {
       "message_received": "Message received",
       "phrase_received": "Phrase received"
+    }
+  },
+  "selector": {
+    "match_type": {
+      "options": {
+        "contains": "Contains",
+        "exact": "Exact",
+        "regex": "Regular expression"
+      }
+    }
+  },
+  "triggers": {
+    "message_received": {
+      "name": "Message received",
+      "description": "Triggers when one or more BlueBubbles messages are received."
+    },
+    "phrase_received": {
+      "name": "Phrase received",
+      "description": "Triggers when one or more BlueBubbles messages match a phrase.",
+      "fields": {
+        "phrase": {
+          "name": "Phrase",
+          "description": "Text to match against the inbound message body."
+        },
+        "match_type": {
+          "name": "Match type",
+          "description": "How the phrase is compared to the message text."
+        }
+      }
     }
   }
 }

--- a/custom_components/bluebubbles/trigger.py
+++ b/custom_components/bluebubbles/trigger.py
@@ -1,0 +1,177 @@
+"""Integration triggers for BlueBubbles inbound messages.
+
+These purpose-specific triggers appear under Automations → Add trigger →
+search "BlueBubbles" (modern Home Assistant trigger platform API).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_OPTIONS, CONF_TARGET
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.trigger import Trigger
+from homeassistant.helpers.typing import ConfigType
+
+from .const import (
+    CONF_MATCH_TYPE,
+    CONF_PHRASE,
+    EVENT_MESSAGE_RECEIVED,
+    MATCH_TYPE_CONTAINS,
+    MATCH_TYPES,
+    TRIGGER_TYPE_MESSAGE_RECEIVED,
+    TRIGGER_TYPE_PHRASE_RECEIVED,
+)
+from .matching import phrase_matches
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.trigger import (
+        TriggerActionRunner,
+        TriggerConfig,
+        TriggerNotTriggeredReporter,
+    )
+
+_MESSAGE_RECEIVED_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS, default={}): {},
+    }
+)
+
+_PHRASE_RECEIVED_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TARGET): cv.TARGET_FIELDS,
+        vol.Required(CONF_OPTIONS, default={}): {
+            vol.Required(CONF_PHRASE): cv.string,
+            vol.Optional(CONF_MATCH_TYPE, default=MATCH_TYPE_CONTAINS): vol.In(
+                MATCH_TYPES
+            ),
+        },
+    }
+)
+
+
+def _payload_from_event(data: dict[str, Any]) -> dict[str, Any]:
+    """Map inbound event data onto automation trigger variables."""
+    text = str(data.get("text") or "")
+    return {
+        "text": text,
+        "message": text,
+        "sender": data.get("sender", ""),
+        "sender_name": data.get("sender_name", ""),
+        "chat_guid": data.get("chat_guid", ""),
+        "chat_identifier": data.get("chat_identifier", ""),
+        "message_guid": data.get("message_guid", ""),
+        "is_from_me": data.get("is_from_me", False),
+        "timestamp": data.get("timestamp"),
+        "attachments": data.get("attachments") or [],
+        "service": data.get("service", ""),
+        "subject": data.get("subject", ""),
+        "device_id": data.get("device_id", ""),
+        "entry_id": data.get("entry_id", ""),
+    }
+
+
+class BlueBubblesMessageTrigger(Trigger):
+    """Base trigger that listens for ``bluebubbles_message_received``."""
+
+    _schema: vol.Schema = _MESSAGE_RECEIVED_SCHEMA
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate trigger-specific config."""
+        return cast(ConfigType, cls._schema(config))
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize trigger."""
+        super().__init__(hass, config)
+        self._key = config.key
+        self._target = config.target
+        self._options = config.options or {}
+
+    @callback
+    def _allowed_device_ids(self) -> set[str] | None:
+        """Return targeted device ids, or None to accept every BlueBubbles device."""
+        if not self._target:
+            return None
+        device_ids = self._target.get("device_id") or []
+        return set(device_ids) if device_ids else None
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        """Return whether this inbound message should fire the trigger."""
+        return True
+
+    @callback
+    def _extra_payload(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Return trigger-specific extra payload fields."""
+        return {}
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: TriggerNotTriggeredReporter | None = None,
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger to the inbound message bus event."""
+        allowed = self._allowed_device_ids()
+
+        @callback
+        def _handle_event(event: Event) -> None:
+            data = dict(event.data)
+            device_id = data.get("device_id")
+            if allowed is not None and device_id not in allowed:
+                return
+            if not self._event_matches(data):
+                return
+
+            payload = {**_payload_from_event(data), **self._extra_payload(data)}
+            sender = payload.get("sender") or "unknown"
+            run_action(
+                payload,
+                f"BlueBubbles message from {sender}",
+                event.context,
+            )
+
+        return self._hass.bus.async_listen(EVENT_MESSAGE_RECEIVED, _handle_event)
+
+
+class MessageReceivedTrigger(BlueBubblesMessageTrigger):
+    """Fire for every inbound BlueBubbles message (after inbound filters)."""
+
+    _schema = _MESSAGE_RECEIVED_SCHEMA
+
+
+class PhraseReceivedTrigger(BlueBubblesMessageTrigger):
+    """Fire when inbound message text matches a configured phrase."""
+
+    _schema = _PHRASE_RECEIVED_SCHEMA
+
+    @callback
+    def _event_matches(self, data: dict[str, Any]) -> bool:
+        text = str(data.get("text") or "")
+        phrase = str(self._options.get(CONF_PHRASE) or "")
+        match_type = self._options.get(CONF_MATCH_TYPE, MATCH_TYPE_CONTAINS)
+        return phrase_matches(text, phrase, match_type)
+
+    @callback
+    def _extra_payload(self, data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "matched_phrase": str(self._options.get(CONF_PHRASE) or ""),
+            "match_type": self._options.get(CONF_MATCH_TYPE, MATCH_TYPE_CONTAINS),
+        }
+
+
+TRIGGERS: dict[str, type[Trigger]] = {
+    TRIGGER_TYPE_MESSAGE_RECEIVED: MessageReceivedTrigger,
+    TRIGGER_TYPE_PHRASE_RECEIVED: PhraseReceivedTrigger,
+}
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+    """Return triggers provided by BlueBubbles."""
+    return TRIGGERS

--- a/custom_components/bluebubbles/triggers.yaml
+++ b/custom_components/bluebubbles/triggers.yaml
@@ -1,0 +1,25 @@
+message_received:
+  target:
+    device:
+      integration: bluebubbles
+
+phrase_received:
+  target:
+    device:
+      integration: bluebubbles
+  fields:
+    phrase:
+      required: true
+      example: Send Me The Bill
+      selector:
+        text:
+    match_type:
+      required: true
+      default: contains
+      selector:
+        select:
+          translation_key: match_type
+          options:
+            - contains
+            - exact
+            - regex

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ha-bluebubbles",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A project for managing BlueBubbles integration.",
   "author": "Helvio Pedreschi",
   "license": "MIT",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
 aiohttp>=3.9.0,<4.0.0
-pytest-homeassistant-custom-component>=0.13.190
+pytest-homeassistant-custom-component>=0.13.355

--- a/tests/test_device_trigger.py
+++ b/tests/test_device_trigger.py
@@ -76,6 +76,58 @@ async def test_async_get_triggers(hass: HomeAssistant, aioclient_mock) -> None:
     assert types == {TRIGGER_TYPE_MESSAGE_RECEIVED, TRIGGER_TYPE_PHRASE_RECEIVED}
 
 
+async def test_device_triggers_listed_when_inbound_disabled(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """Device triggers stay discoverable when inbound webhooks are off."""
+    aioclient_mock.get(
+        f"{MOCK_HOST}/api/v1/server/info",
+        json={
+            "status": 200,
+            "data": {"private_api": True, "detected_imessage": "user@icloud.com"},
+        },
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_PASSWORD: MOCK_PASSWORD,
+            CONF_SSL: False,
+            "private_api": True,
+        },
+        title="user@icloud.com",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    assert device is not None
+    triggers = await device_trigger.async_get_triggers(hass, device.id)
+    assert {trigger[CONF_TYPE] for trigger in triggers} == {
+        TRIGGER_TYPE_MESSAGE_RECEIVED,
+        TRIGGER_TYPE_PHRASE_RECEIVED,
+    }
+
+
+async def test_async_validate_trigger_config(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """TRIGGER_SCHEMA validation accepts a message_received device trigger."""
+    _entry, device_id = await _setup_entry(hass, aioclient_mock)
+    validated = await device_trigger.async_validate_trigger_config(
+        hass,
+        {
+            CONF_PLATFORM: "device",
+            CONF_DOMAIN: DOMAIN,
+            CONF_DEVICE_ID: device_id,
+            CONF_TYPE: TRIGGER_TYPE_MESSAGE_RECEIVED,
+        },
+    )
+    assert validated[CONF_TYPE] == TRIGGER_TYPE_MESSAGE_RECEIVED
+
+
 async def test_phrase_capabilities_include_match_fields(
     hass: HomeAssistant, aioclient_mock
 ) -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -67,7 +67,7 @@ async def test_diagnostics_redacts_password(
     assert result["inbound_enabled"] is True
     assert result["webhook_path"] == f"/api/webhook/{WEBHOOK_ID}"
     assert result["private_api"] is True
-    assert result["integration_version"] == "0.5.0"
+    assert result["integration_version"] == "0.6.0"
 
     config_data = result["config_entry"]["data"]
     assert config_data[CONF_HOST] == MOCK_HOST

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,114 @@
+"""Tests for the BlueBubbles event entity."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bluebubbles.const import (
+    CONF_ENABLE_INBOUND,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SSL,
+    CONF_WEBHOOK_ID,
+    DOMAIN,
+    EVENT_MESSAGE_RECEIVED,
+    TRIGGER_TYPE_MESSAGE_RECEIVED,
+)
+
+MOCK_HOST = "http://127.0.0.1:1234"
+MOCK_PASSWORD = "test-password"
+WEBHOOK_ID = "event-entity-webhook"
+
+
+async def _setup_entry(
+    hass: HomeAssistant, aioclient_mock, *, enable_inbound: bool = True
+) -> tuple[MockConfigEntry, str]:
+    aioclient_mock.get(
+        f"{MOCK_HOST}/api/v1/server/info",
+        json={
+            "status": 200,
+            "data": {"private_api": True, "detected_imessage": "user@icloud.com"},
+        },
+    )
+    options = {}
+    if enable_inbound:
+        options = {
+            CONF_ENABLE_INBOUND: True,
+            CONF_WEBHOOK_ID: WEBHOOK_ID,
+            "auto_register_webhook": False,
+            "webhook_local_only": True,
+            "include_from_me": False,
+            "allowed_handles": "",
+        }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_PASSWORD: MOCK_PASSWORD,
+            CONF_SSL: False,
+            "private_api": True,
+        },
+        options=options,
+        title="user@icloud.com",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    assert device is not None
+    return entry, device.id
+
+
+async def test_event_entity_created_with_inbound_disabled(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """Event entity exists even when inbound is left off (default)."""
+    await _setup_entry(hass, aioclient_mock, enable_inbound=False)
+    states = [
+        state
+        for state in hass.states.async_all("event")
+        if "message" in state.entity_id
+    ]
+    assert len(states) == 1
+    assert states[0].entity_id == "event.user_icloud_com_message"
+    assert states[0].attributes.get("event_types") == [TRIGGER_TYPE_MESSAGE_RECEIVED]
+
+
+async def test_event_entity_fires_on_inbound(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """Inbound bus events update the event entity attributes."""
+    _entry, device_id = await _setup_entry(hass, aioclient_mock)
+    states = [state for state in hass.states.async_all("event") if "message" in state.entity_id]
+    assert len(states) == 1
+    entity_id = states[0].entity_id
+
+    hass.bus.async_fire(
+        EVENT_MESSAGE_RECEIVED,
+        {
+            "device_id": device_id,
+            "text": "Hello event entity",
+            "sender": "+15551234567",
+            "sender_name": "Pat",
+            "chat_guid": "any;-;+15551234567",
+            "chat_identifier": "+15551234567",
+            "message_guid": "m-event-1",
+            "is_from_me": False,
+            "timestamp": 99,
+            "attachments": [],
+            "service": "iMessage",
+            "subject": "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes.get("event_type") == TRIGGER_TYPE_MESSAGE_RECEIVED
+    assert state.attributes.get("text") == "Hello event entity"
+    assert state.attributes.get("sender") == "+15551234567"
+    assert state.attributes.get("chat_guid") == "any;-;+15551234567"

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,0 +1,237 @@
+"""Tests for BlueBubbles integration triggers."""
+
+from __future__ import annotations
+
+from homeassistant.components import automation
+from homeassistant.const import CONF_OPTIONS, CONF_PLATFORM
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_mock_service,
+)
+
+from custom_components.bluebubbles import trigger as bb_trigger
+from custom_components.bluebubbles.const import (
+    CONF_ENABLE_INBOUND,
+    CONF_HOST,
+    CONF_MATCH_TYPE,
+    CONF_PASSWORD,
+    CONF_PHRASE,
+    CONF_SSL,
+    CONF_WEBHOOK_ID,
+    DOMAIN,
+    EVENT_MESSAGE_RECEIVED,
+    MATCH_TYPE_CONTAINS,
+    MATCH_TYPE_EXACT,
+    TRIGGER_TYPE_MESSAGE_RECEIVED,
+    TRIGGER_TYPE_PHRASE_RECEIVED,
+)
+
+MOCK_HOST = "http://127.0.0.1:1234"
+MOCK_PASSWORD = "test-password"
+WEBHOOK_ID = "integration-trigger-webhook"
+
+
+async def _setup_entry(hass: HomeAssistant, aioclient_mock) -> tuple[MockConfigEntry, str]:
+    aioclient_mock.get(
+        f"{MOCK_HOST}/api/v1/server/info",
+        json={
+            "status": 200,
+            "data": {"private_api": True, "detected_imessage": "user@icloud.com"},
+        },
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_PASSWORD: MOCK_PASSWORD,
+            CONF_SSL: False,
+            "private_api": True,
+        },
+        options={
+            CONF_ENABLE_INBOUND: True,
+            CONF_WEBHOOK_ID: WEBHOOK_ID,
+            "auto_register_webhook": False,
+            "webhook_local_only": True,
+            "include_from_me": False,
+            "allowed_handles": "",
+        },
+        title="user@icloud.com",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    assert device is not None
+    return entry, device.id
+
+
+async def test_async_get_triggers_registers_both_types(hass: HomeAssistant) -> None:
+    """Integration trigger platform exposes message_received and phrase_received."""
+    triggers = await bb_trigger.async_get_triggers(hass)
+    assert set(triggers) == {
+        TRIGGER_TYPE_MESSAGE_RECEIVED,
+        TRIGGER_TYPE_PHRASE_RECEIVED,
+    }
+
+
+async def test_triggers_visible_when_inbound_disabled(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """Trigger registration is not gated on enable_inbound."""
+    aioclient_mock.get(
+        f"{MOCK_HOST}/api/v1/server/info",
+        json={
+            "status": 200,
+            "data": {"private_api": True, "detected_imessage": "user@icloud.com"},
+        },
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: MOCK_HOST,
+            CONF_PASSWORD: MOCK_PASSWORD,
+            CONF_SSL: False,
+            "private_api": True,
+        },
+        title="user@icloud.com",
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    triggers = await bb_trigger.async_get_triggers(hass)
+    assert TRIGGER_TYPE_MESSAGE_RECEIVED in triggers
+    assert TRIGGER_TYPE_PHRASE_RECEIVED in triggers
+
+
+async def test_message_received_integration_trigger_fires(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """bluebubbles.message_received runs automations on inbound events."""
+    _entry, device_id = await _setup_entry(hass, aioclient_mock)
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: f"{DOMAIN}.{TRIGGER_TYPE_MESSAGE_RECEIVED}",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {
+                            "text": "{{ trigger.text }}",
+                            "sender": "{{ trigger.sender }}",
+                            "chat_guid": "{{ trigger.chat_guid }}",
+                        },
+                    },
+                }
+            ]
+        },
+    )
+
+    hass.bus.async_fire(
+        EVENT_MESSAGE_RECEIVED,
+        {
+            "device_id": device_id,
+            "text": "Front door",
+            "sender": "+15551234567",
+            "sender_name": "",
+            "chat_guid": "any;-;+15551234567",
+            "chat_identifier": "+15551234567",
+            "message_guid": "m1",
+            "is_from_me": False,
+            "timestamp": 1,
+            "attachments": [],
+            "service": "iMessage",
+            "subject": "",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert calls[0].data["text"] == "Front door"
+    assert "15551234567" in str(calls[0].data["sender"])
+    assert calls[0].data["chat_guid"] == "any;-;+15551234567"
+
+
+async def test_phrase_received_integration_trigger(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """bluebubbles.phrase_received supports contains matching via options."""
+    _entry, device_id = await _setup_entry(hass, aioclient_mock)
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: f"{DOMAIN}.{TRIGGER_TYPE_PHRASE_RECEIVED}",
+                        CONF_OPTIONS: {
+                            CONF_PHRASE: "bill",
+                            CONF_MATCH_TYPE: MATCH_TYPE_CONTAINS,
+                        },
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {
+                            "which": "hit",
+                            "matched": "{{ trigger.matched_phrase }}",
+                        },
+                    },
+                }
+            ]
+        },
+    )
+
+    async def _fire(text: str) -> None:
+        hass.bus.async_fire(
+            EVENT_MESSAGE_RECEIVED,
+            {
+                "device_id": device_id,
+                "text": text,
+                "sender": "+15551234567",
+                "sender_name": "",
+                "chat_guid": "any;-;+15551234567",
+                "chat_identifier": "+15551234567",
+                "message_guid": "m1",
+                "is_from_me": False,
+                "timestamp": 1,
+                "attachments": [],
+                "service": "iMessage",
+                "subject": "",
+            },
+        )
+        await hass.async_block_till_done()
+
+    await _fire("nope")
+    await _fire("Send me the bill please")
+    assert len(calls) == 1
+    assert calls[0].data["which"] == "hit"
+    assert calls[0].data["matched"] == "bill"
+
+
+async def test_phrase_validate_config_requires_phrase(hass: HomeAssistant) -> None:
+    """phrase_received validation requires a phrase option."""
+    cls = bb_trigger.TRIGGERS[TRIGGER_TYPE_PHRASE_RECEIVED]
+    validated = await cls.async_validate_config(
+        hass,
+        {
+            CONF_OPTIONS: {
+                CONF_PHRASE: "Status",
+                CONF_MATCH_TYPE: MATCH_TYPE_EXACT,
+            }
+        },
+    )
+    assert validated[CONF_OPTIONS][CONF_PHRASE] == "Status"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why triggers were invisible

0.5.0 shipped `device_trigger.py` + inbound webhooks, but users still reported **no BlueBubbles triggers** in Home Assistant for three compounding reasons:

1. **Discoverability** — Device triggers only appear under **Automations → Device → select the BlueBubbles device**. They do **not** show up as a searchable “BlueBubbles” trigger type in the main trigger picker, so many users concluded the integration had no triggers.
2. **Silent load failure risk** — Bad imports in `device_trigger.py` fail the device-automation platform with little/no log (HA core #39649 / #100783). Hand-rolled bus listeners were also more fragile than wrapping the core event trigger helper.
3. **Modern HA UX** — Current Home Assistant expects purpose-specific integration triggers (`trigger.py` + `triggers.yaml`) so the integration appears by name when adding a trigger.

Inbound being opt-in was fine for safety, but trigger registration must not be confused with “triggers don’t exist.”

## What 0.6.0 changes

### Integration triggers (main UX fix)
- Adds `trigger.py` with `MessageReceivedTrigger` / `PhraseReceivedTrigger` and `async_get_triggers`
- Adds `triggers.yaml` + strings/translations for **Message received** and **Phrase received**
- Users can: **Automations → Add trigger → search “BlueBubbles”**

### Hardened device triggers
- `TRIGGER_SCHEMA` remains a module-level constant
- Adds `async_validate_trigger_config`
- `async_attach_trigger` now wraps `homeassistant.components.homeassistant.triggers.event` (filters by `device_id`, keeps flattened `trigger.text` / `trigger.sender` / … for existing automations)
- Phrase matching uses shared `matching.py`
- Triggers stay listed even when inbound is disabled (they simply won’t fire)

### Event entity
- New `event` platform entity (`event.<device>_message`) fires on inbound messages with text/sender/chat attributes
- Useful in Developer Tools and as a generic event-entity trigger
- Created even when inbound is off; additive for existing installs

### Docs / release
- README documents both click-paths and upgrade via HACS to **0.6.0**
- Version bumped in `manifest.json` + `package.json`
- CI/tests moved to Python **3.14** + `pytest-homeassistant-custom-component>=0.13.355` (HA 2026.8) so the modern trigger API is exercised

## Compatibility

- No breaking changes to `bluebubbles.send_message`, config entry data keys, or options defaults
- No re-add required
- `integration_type: service` kept; device registry entry with `(DOMAIN, entry_id)` identifiers is unchanged so device triggers still match

## Test plan

- [x] `pytest` — 35 passed (device triggers, integration triggers, event entity, inbound, send, diagnostics)
- [ ] GitHub Actions hassfest / HACS / pytest green on the PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70401fd6-e997-4aa1-8c71-8db21b32aa9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70401fd6-e997-4aa1-8c71-8db21b32aa9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

