### PR TITLE
Add support for sending messages by chat GUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,28 +219,6 @@ data:
 
 You can also call this service from the Developer Tools > Services page for testing.
 
-#### Sending to an existing chat
-
-Use the chat GUID exposed by an inbound message to reply to that exact conversation,
-including an existing group chat. Sending by chat GUID does not require the Private API:
-
-```yaml
-service: bluebubbles.send_message
-data:
-  chat_guid: "any;+;bd802086b5494bb6a197b0c10625f9e9"
-  message: "Reply from Home Assistant"
-```
-
-In an automation triggered by an inbound BlueBubbles message, it can be templated:
-
-```yaml
-action:
-  - service: bluebubbles.send_message
-    data:
-      chat_guid: "{{ trigger.chat_guid }}"
-      message: "Thanks, I received your message."
-```
-
 ## Breaking changes
 
 **None.** Config entries, `send_message` fields, option keys for existing setups, and translations for current outbound use remain compatible. Inbound messaging is additive and disabled until you enable it in Configure.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ trigger:
 
 Sends a message via BlueBubbles (iMessage/RCS/SMS/MMS depending on recipients).
 
-- **addresses**: The address(es) to send to—phone numbers or emails, separated by commas or semicolons for groups (requires Private API enabled on your server). Required.
+- **addresses**: The address(es) to send to—phone numbers or emails, separated by commas or semicolons for groups (requires Private API enabled on your server). Provide exactly one of `addresses` or `chat_guid`.
+- **chat_guid**: The GUID of an existing BlueBubbles chat, such as the `trigger.chat_guid` value from an inbound message. Provide exactly one of `chat_guid` or `addresses`.
 - **message**: The message to send. Optional when `attachment` or `media_url` is provided.
 - **attachment**: Absolute path to a local file to attach (for example a camera snapshot under `/config/www/`). The path must be allowed via [`allowlist_external_dirs`](https://www.home-assistant.io/docs/configuration/basic/#allowlist_external_dirs). Optional.
 - **media_url**: URL of an image/file to download and attach. Used when `attachment` is not set. Optional.
@@ -217,6 +218,28 @@ data:
 ```
 
 You can also call this service from the Developer Tools > Services page for testing.
+
+#### Sending to an existing chat
+
+Use the chat GUID exposed by an inbound message to reply to that exact conversation,
+including an existing group chat. Sending by chat GUID does not require the Private API:
+
+```yaml
+service: bluebubbles.send_message
+data:
+  chat_guid: "any;+;bd802086b5494bb6a197b0c10625f9e9"
+  message: "Reply from Home Assistant"
+```
+
+In an automation triggered by an inbound BlueBubbles message, it can be templated:
+
+```yaml
+action:
+  - service: bluebubbles.send_message
+    data:
+      chat_guid: "{{ trigger.chat_guid }}"
+      message: "Thanks, I received your message."
+```
 
 ## Breaking changes
 

--- a/custom_components/bluebubbles/__init__.py
+++ b/custom_components/bluebubbles/__init__.py
@@ -96,43 +96,54 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         send_api = runtime_data.api if runtime_data else api
 
         addresses_str = str(service_call.data.get("addresses", "")).strip()
+        chat_guid = str(service_call.data.get("chat_guid", "")).strip()
         message = str(service_call.data.get("message", "")).strip()
         attachment_path = str(service_call.data.get("attachment", "")).strip()
         media_url = str(service_call.data.get("media_url", "")).strip()
 
-        if not addresses_str:
-            raise HomeAssistantError("At least one address is required")
+        if bool(addresses_str) == bool(chat_guid):
+            raise HomeAssistantError(
+                "Provide exactly one of addresses or chat_guid"
+            )
         if not message and not attachment_path and not media_url:
             raise HomeAssistantError(
                 "Message, attachment, or media_url is required"
             )
 
-        addresses = [
-            n.strip() for n in re.split(r"[,;]", addresses_str) if n.strip()
-        ]
-        if not addresses:
-            raise HomeAssistantError("No valid addresses provided")
-
-        if not private_api and len(addresses) > 1:
-            raise HomeAssistantError(
-                "Sending to multiple addresses is only supported when Private "
-                "API is enabled on your BlueBubbles server. Please use a single "
-                "address or enable Private API for group messaging."
-            )
-
         method = "private-api" if private_api else "apple-script"
 
-        chat_result = await send_api.async_create_chat(
-            addresses,
-            message=message or None,
-            method=method,
-        )
+        if chat_guid:
+            if message:
+                await send_api.async_send_text(
+                    chat_guid,
+                    message,
+                    method=method,
+                )
+        else:
+            addresses = [
+                n.strip() for n in re.split(r"[,;]", addresses_str) if n.strip()
+            ]
+            if not addresses:
+                raise HomeAssistantError("No valid addresses provided")
+
+            if not private_api and len(addresses) > 1:
+                raise HomeAssistantError(
+                    "Sending to multiple addresses is only supported when Private "
+                    "API is enabled on your BlueBubbles server. Please use a single "
+                    "address or enable Private API for group messaging."
+                )
+
+            chat_result = await send_api.async_create_chat(
+                addresses,
+                message=message or None,
+                method=method,
+            )
+            chat_guid = (chat_result.get("data") or {}).get("guid") or ""
 
         if not attachment_path and not media_url:
             _LOGGER.debug("Message sent successfully")
             return
 
-        chat_guid = (chat_result.get("data") or {}).get("guid")
         if not chat_guid:
             raise HomeAssistantError(
                 "BlueBubbles did not return a chat GUID required to send "

--- a/custom_components/bluebubbles/api.py
+++ b/custom_components/bluebubbles/api.py
@@ -225,6 +225,47 @@ class BlueBubblesApi:
                 f"Cannot connect to BlueBubbles server: {err}"
             ) from err
 
+    async def async_send_text(
+        self,
+        chat_guid: str,
+        message: str,
+        *,
+        method: str = "apple-script",
+    ) -> dict[str, Any]:
+        """Send text to an existing chat via /api/v1/message/text."""
+        url = f"{self._host}/api/v1/message/text"
+        payload = {
+            "chatGuid": chat_guid,
+            "tempGuid": f"temp-{uuid.uuid4()}",
+            "message": message,
+            "method": method,
+        }
+
+        try:
+            async with self._session.post(
+                url,
+                json=payload,
+                params=self._params,
+                ssl=self._ssl,
+            ) as response:
+                return await async_parse_response(
+                    response,
+                    password=self._password,
+                    context="BlueBubbles send message",
+                )
+        except HomeAssistantError:
+            raise
+        except aiohttp.ClientError as err:
+            safe_payload = redact_secrets(
+                json.dumps(payload), [self._password]
+            )
+            _LOGGER.error(
+                "Error sending message: %s. Payload: %s", err, safe_payload
+            )
+            raise HomeAssistantError(
+                f"Cannot connect to BlueBubbles server: {err}"
+            ) from err
+
     async def async_send_attachment(
         self,
         chat_guid: str,

--- a/custom_components/bluebubbles/services.yaml
+++ b/custom_components/bluebubbles/services.yaml
@@ -4,9 +4,16 @@ send_message:
   fields:
     addresses:
       name: Address(es)
-      description: The address(es) to send to. Multiple addresses can be separated by commas or semicolons.
-      required: true
+      description: The address(es) to send to. Multiple addresses can be separated by commas or semicolons. Provide either addresses or chat_guid.
+      required: false
       example: "+15558675309, a.contact@me.com"
+      selector:
+        text:
+    chat_guid:
+      name: Chat GUID
+      description: The GUID of an existing BlueBubbles chat. Provide either chat_guid or addresses.
+      required: false
+      example: "any;+;bd802086b5494bb6a197b0c10625f9e9"
       selector:
         text:
     message:

--- a/tests/test_send_message.py
+++ b/tests/test_send_message.py
@@ -15,29 +15,34 @@ MOCK_HOST = "http://127.0.0.1:1234"
 MOCK_PASSWORD = "test-password"
 
 
-def _mock_entry() -> MockConfigEntry:
+def _mock_entry(*, private_api: bool = True) -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         data={
             CONF_HOST: MOCK_HOST,
             CONF_PASSWORD: MOCK_PASSWORD,
             CONF_SSL: False,
-            "private_api": True,
+            "private_api": private_api,
         },
         title="user@icloud.com",
     )
 
 
-async def _setup_integration(hass: HomeAssistant, aioclient_mock) -> MockConfigEntry:
+async def _setup_integration(
+    hass: HomeAssistant, aioclient_mock, *, private_api: bool = True
+) -> MockConfigEntry:
     aioclient_mock.get(
         f"{MOCK_HOST}/api/v1/server/info",
         json={
             "status": 200,
             "message": "Success",
-            "data": {"private_api": True, "detected_imessage": "user@icloud.com"},
+            "data": {
+                "private_api": private_api,
+                "detected_imessage": "user@icloud.com",
+            },
         },
     )
-    entry = _mock_entry()
+    entry = _mock_entry(private_api=private_api)
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -68,6 +73,100 @@ async def test_send_message_maps_api_error_to_homeassistant_error(
         )
 
     assert "Unknown error" not in str(err.value)
+
+
+async def test_send_message_by_chat_guid_without_private_api(
+    hass: HomeAssistant, aioclient_mock
+) -> None:
+    """An existing chat GUID is sent directly and is not split on semicolons."""
+    await _setup_integration(hass, aioclient_mock, private_api=False)
+    chat_guid = "any;+;bd802086b5494bb6a197b0c10625f9e9"
+    aioclient_mock.post(
+        f"{MOCK_HOST}/api/v1/message/text",
+        json={
+            "status": 200,
+            "message": "Successfully sent message!",
+            "data": {"guid": "message-guid"},
+        },
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "send_message",
+        {"chat_guid": chat_guid, "message": "hello"},
+        blocking=True,
+    )
+
+    calls = [
+        call
+        for call in aioclient_mock.mock_calls
+        if call[1].path == "/api/v1/message/text"
+    ]
+    assert len(calls) == 1
+    assert calls[0][2]["chatGuid"] == chat_guid
+    assert calls[0][2]["message"] == "hello"
+    assert calls[0][2]["method"] == "apple-script"
+    assert calls[0][2]["tempGuid"].startswith("temp-")
+    assert all(call[1].path != "/api/v1/chat/new" for call in aioclient_mock.mock_calls)
+
+
+@pytest.mark.parametrize(
+    "service_data",
+    [
+        {"message": "hello"},
+        {
+            "addresses": "+15551234567",
+            "chat_guid": "any;-;+15551234567",
+            "message": "hello",
+        },
+    ],
+)
+async def test_send_message_requires_exactly_one_destination(
+    hass: HomeAssistant, aioclient_mock, service_data: dict[str, str]
+) -> None:
+    """The service rejects missing or ambiguous destinations."""
+    await _setup_integration(hass, aioclient_mock)
+
+    with pytest.raises(
+        HomeAssistantError, match="Provide exactly one of addresses or chat_guid"
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "send_message",
+            service_data,
+            blocking=True,
+        )
+
+
+async def test_send_attachment_by_chat_guid_skips_chat_creation(
+    hass: HomeAssistant, aioclient_mock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An attachment can be sent directly to an existing chat."""
+    await _setup_integration(hass, aioclient_mock)
+    chat_guid = "any;+;bd802086b5494bb6a197b0c10625f9e9"
+    image_path = tmp_path / "snapshot.jpg"
+    image_path.write_bytes(b"fake-image-bytes")
+    monkeypatch.setattr(hass.config, "is_allowed_path", lambda path: True)
+    aioclient_mock.post(
+        f"{MOCK_HOST}/api/v1/message/attachment",
+        json={
+            "status": 200,
+            "message": "Successfully sent attachment!",
+            "data": {"guid": "message-guid"},
+        },
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "send_message",
+        {"chat_guid": chat_guid, "attachment": str(image_path)},
+        blocking=True,
+    )
+
+    paths = [req[1].path for req in aioclient_mock.mock_calls]
+    assert "/api/v1/message/attachment" in paths
+    assert "/api/v1/chat/new" not in paths
+    assert "/api/v1/message/text" not in paths
 
 
 async def test_send_message_attachment_happy_path(


### PR DESCRIPTION
## Summary

- add an optional `chat_guid` destination to `bluebubbles.send_message`, mutually exclusive with `addresses`
- send text directly to existing chats through `/api/v1/message/text`
- support text and attachments by chat GUID without requiring the Private API
- document the new service field and retain existing address-based behavior

## Testing

- `pytest -q` — 39 passed