### PR TITLE
Tighten README and bump to 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,112 +1,93 @@
-# BlueBubbles Integration for Home Assistant
+# BlueBubbles
 
-Send and receive iMessage/RCS/SMS/MMS from Home Assistant via a [BlueBubbles](https://bluebubbles.app) server.
-
-## Architecture
-
-- **Outbound**: `bluebubbles.send_message` talks to the BlueBubbles REST API (`/api/v1/chat/new`, `/api/v1/message/attachment`) through a shared `aiohttp` session (`async_get_clientsession`).
-- **Inbound** (optional): Home Assistant registers a webhook (`/api/webhook/<id>`). BlueBubbles POSTs `new-message` events to it (auto-registered via `/api/v1/webhook` when enabled, or manually in the BlueBubbles UI).
-- **Automations**: Integration triggers (`bluebubbles.message_received` / `bluebubbles.phrase_received`) and device triggers on the BlueBubbles device, all backed by the `bluebubbles_message_received` event. An `event.bluebubbles_message` entity also fires for Developer Tools / state-style triggers.
-
-Existing installs that only send messages keep working with no reconfigure — inbound is opt-in under **Configure**.
-
-## Upgrading to 0.6.0
-
-0.6.0 is additive (no re-add required). After updating via HACS and reloading/restarting:
-
-1. Send-only setups need no changes.
-2. Triggers are discoverable by name: **Settings → Automations → Add trigger → search “BlueBubbles”**.
-3. Or use **Device → BlueBubbles → Message received / Phrase received**.
-4. To receive messages, open **Configure**, enable inbound webhooks, and save (a stable webhook id is created for you). Triggers stay visible even when inbound is off; they simply will not fire until inbound is enabled.
+Home Assistant custom integration that sends and receives iMessage, RCS, SMS, and MMS via a [BlueBubbles](https://bluebubbles.app) server.
 
 ## Installation
 
-### HACS (Recommended)
-
-#### Option 1: Using My Button
-
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=helv-io&repository=ha-bluebubbles&category=Integration)
 
-After adding the repository, search for "BlueBubbles" in HACS > Integrations and install it. Then, restart Home Assistant.
+After adding the repository, search for BlueBubbles in HACS > Integrations, install it, then restart Home Assistant.
 
-#### Option 2: Manual
+Or add the custom repository by hand:
 
-1. Open HACS in Home Assistant.
-2. Go to "Integrations".
-3. Click the three dots in the top right and select "Custom repositories".
-4. Add `https://github.com/helv-io/ha-bluebubbles` as a repository (category: Integration).
-5. Search for "BlueBubbles" and install it.
-6. Restart Home Assistant.
+1. Open HACS > Integrations.
+2. Three dots > Custom repositories.
+3. Add `https://github.com/helv-io/ha-bluebubbles` (category: Integration).
+4. Search for BlueBubbles and install.
+5. Restart Home Assistant.
 
-### Manual Installation
+Without HACS, copy `custom_components/bluebubbles/` from a [release][releases] into your Home Assistant config directory and restart.
 
-1. Download the latest release from the [releases page][releases].
-2. Extract the contents to `custom_components/bluebubbles/` in your Home Assistant configuration directory.
-3. Restart Home Assistant.
+## Setup
 
-## How to Setup
+BlueBubbles server install is covered on the [BlueBubbles website][bluebubbles-website].
 
-This integration uses Home Assistant's configuration flow for setup. BlueBubbles server setup is outside the scope of this integration. Head over to the [BlueBubbles website][bluebubbles-website] for details on getting your server running.
+1. Settings > Devices & Services > Add Integration > BlueBubbles.
+2. Enter:
+   - **Host**: BlueBubbles server URL (`http://192.168.1.100:1234` or `https://your-domain.com`)
+   - **Password**: the password set on the BlueBubbles server
+   - **SSL** (optional, default off): leave off for a self-signed certificate
+3. Submit. The integration connects, reads server info, and names the entry from the detected iMessage account.
 
-1. In Home Assistant, go to Settings > Devices & Services.
-2. Click "Add Integration" and search for "BlueBubbles".
-3. You'll be prompted for the following:
-   - **Host**: The URL of your BlueBubbles server (e.g., `http://192.168.1.100:1234` or `https://your-domain.com`).
-   - **Password**: The password set in your BlueBubbles server.
-   - **SSL** (optional, default: false): Enable if your server uses HTTPS with a self-signed certificate.
-4. Submit the form. The integration will attempt to connect, fetch server details (including your iMessage account for naming), and verify.
-5. If successful, the integration will be added with a title based on your detected iMessage account (e.g., "user@example.com").
+The first send may show a macOS permission prompt on the machine running BlueBubbles. Accept it or sending will fail. See the [BlueBubbles docs][bluebubbles-docs].
 
-**Important Note**: After initial setup, you may need to send a test message through the service. On the macOS machine running the BlueBubbles server app, a permission prompt might appear. Click to accept and grant access for message sending to work properly. Refer to the [BlueBubbles documentation][bluebubbles-docs] for more on permissions.
+Private API on the BlueBubbles server is required to send to more than one address. The integration reads that flag on setup and on Home Assistant restart.
 
-The integration automatically detects if Private API is enabled on your server and updates this on Home Assistant restarts. Private API is required for sending to multiple addresses (group messages); without it, only single-address sends are supported.
+Inbound webhooks are off until you enable them under **Configure**. Send-only setups do not need to change.
 
-## Inbound messages & triggers
+## send_message
 
-Inbound messaging is **opt-in** so existing send-only setups are unchanged. Jump to [Example automations](#example-automations) for copy-paste YAML.
+`bluebubbles.send_message` sends iMessage, RCS, SMS, or MMS depending on the recipients.
 
-1. Open **Settings → Devices & Services → BlueBubbles → Configure**.
-2. Enable **Enable inbound message webhooks**.
-3. Leave **Auto-register webhook with BlueBubbles server** on if Home Assistant has a URL the Mac can reach (same LAN is fine, e.g. `http://homeassistant.local:8123`).
-4. Save. The options form shows the webhook path (for example `/api/webhook/<id>`). Saving Configure always persists a stable `webhook_id` (no ephemeral webhook for normal UX).
+Provide exactly one of `addresses` or `chat_guid`.
 
-### Finding triggers in the UI
+- **addresses**: phone numbers or emails. Separate multiple with commas or semicolons (Private API required for groups).
+- **chat_guid**: GUID of an existing BlueBubbles chat, such as `trigger.chat_guid` from an inbound message.
+- **message**: text to send. Optional when `attachment` or `media_url` is set.
+- **attachment**: absolute path to a local file (for example `/config/www/snapshot.jpg`). The path must be allowed by [`allowlist_external_dirs`](https://www.home-assistant.io/docs/configuration/basic/#allowlist_external_dirs).
+- **media_url**: URL of a file to download and attach. Used when `attachment` is not set.
 
-BlueBubbles does **not** appear as a top-level “trigger type” in older menus the way sun/time do on every screen. Use one of these paths:
+```yaml
+service: bluebubbles.send_message
+data:
+  addresses: "+15551234567, user@example.com"
+  message: "Hello from Home Assistant!"
+```
 
-1. **Recommended:** **Settings → Automations & Scenes → Create automation → Add trigger → search “BlueBubbles”** → choose **Message received** or **Phrase received**.
-2. **Device path:** **Add trigger → Device → select your BlueBubbles device → Message received / Phrase received**.
+```yaml
+service: bluebubbles.send_message
+data:
+  chat_guid: "{{ trigger.chat_guid }}"
+  message: "Front door motion"
+  attachment: "/config/www/snapshot.jpg"
+```
 
-Triggers are registered even when inbound is disabled; they will not fire until inbound webhooks are enabled and BlueBubbles is posting `new-message` events.
+## Inbound messages
 
-### Network notes
+1. Settings > Devices & Services > BlueBubbles > Configure.
+2. Enable inbound message webhooks.
+3. Leave auto-register on if the Mac can reach this Home Assistant URL (same LAN is enough).
+4. Save. The form shows the webhook path (`/api/webhook/<id>`).
 
-- BlueBubbles must be able to **POST** to your Home Assistant webhook URL.
-- On a typical LAN, `http://<ha-host>:8123/api/webhook/<id>` works. Prefer **local only** (default) so the webhook rejects non-local callers.
-- If auto-register fails (no HA URL, older BlueBubbles, etc.), add the webhook manually in **BlueBubbles Server → API & Webhooks → Add Webhook**:
-  - URL: `http(s)://<home-assistant>/api/webhook/<id>`
-  - Events: `new-message`
-- BlueBubbles server **1.0.0+** is required for webhooks.
+BlueBubbles must POST `new-message` events to that URL. Server 1.0.0+ is required. If auto-register fails, add the webhook in BlueBubbles Server > API & Webhooks (events: `new-message`).
 
-### Trigger types
+Triggers (search **BlueBubbles** when adding an automation trigger, or use the BlueBubbles device):
 
 | Trigger | When it fires |
 |---|---|
-| **Message received** | Any inbound message (after filters) |
-| **Phrase received** | Message text matches a phrase (`contains`, `exact`, or `regex`) |
+| Message received | Any inbound message that passes filters |
+| Phrase received | Message text matches a phrase (`contains`, `exact`, or `regex`) |
 
-Trigger data available in templates includes: `trigger.text`, `trigger.sender`, `trigger.sender_name`, `trigger.chat_guid`, `trigger.chat_identifier`, `trigger.message_guid`, `trigger.attachments`, `trigger.timestamp`, `trigger.service`, and for phrase triggers `trigger.matched_phrase`.
+Trigger templates: `trigger.text`, `trigger.sender`, `trigger.sender_name`, `trigger.chat_guid`, `trigger.chat_identifier`, `trigger.message_guid`, `trigger.attachments`, `trigger.timestamp`, `trigger.service`, and `trigger.matched_phrase` on phrase triggers.
 
-The integration also creates **`event.<name>_message`** (translation: Message). It fires on inbound messages with the same attributes, so you can inspect the latest message in Developer Tools → States, or use a generic event-entity trigger.
+`event.<name>_message` updates with the same attributes.
 
-Optional Configure filters:
+Configure filters:
 
-- **Allowed senders** — comma-separated phones/emails; empty means all
-- **Include from me** — also fire on messages sent from the BlueBubbles Mac
+- **Allowed senders**: comma-separated phones or emails. Empty means all.
+- **Include from me**: also fire on messages sent from the BlueBubbles Mac.
 
-### Example automations
-
-Any inbound message → notify (integration trigger):
+Triggers stay listed when inbound is off. They do not fire until inbound is enabled and BlueBubbles is posting `new-message` events.
 
 ```yaml
 automation:
@@ -120,11 +101,9 @@ automation:
           message: "{{ trigger.text }}"
 ```
 
-Phrase match → run a script:
-
 ```yaml
 automation:
-  - alias: Text "Send Me The Bill"
+  - alias: Text Send Me The Bill
     trigger:
       - platform: bluebubbles.phrase_received
         options:
@@ -134,121 +113,23 @@ automation:
       - service: script.send_latest_bill
 ```
 
-Device trigger form (same events):
-
-```yaml
-automation:
-  - alias: iMessage received (device)
-    trigger:
-      - platform: device
-        domain: bluebubbles
-        device_id: YOUR_BLUEBUBBLES_DEVICE_ID
-        type: message_received
-    action:
-      - service: notify.persistent_notification
-        data:
-          title: "iMessage from {{ trigger.sender }}"
-          message: "{{ trigger.text }}"
-```
-
-You can also listen for the raw bus event:
-
-```yaml
-trigger:
-  - platform: event
-    event_type: bluebubbles_message_received
-```
-
-## Services
-
-### send_message
-
-Sends a message via BlueBubbles (iMessage/RCS/SMS/MMS depending on recipients).
-
-- **addresses**: The address(es) to send to—phone numbers or emails, separated by commas or semicolons for groups (requires Private API enabled on your server). Provide exactly one of `addresses` or `chat_guid`.
-- **chat_guid**: The GUID of an existing BlueBubbles chat, such as the `trigger.chat_guid` value from an inbound message. Provide exactly one of `chat_guid` or `addresses`.
-- **message**: The message to send. Optional when `attachment` or `media_url` is provided.
-- **attachment**: Absolute path to a local file to attach (for example a camera snapshot under `/config/www/`). The path must be allowed via [`allowlist_external_dirs`](https://www.home-assistant.io/docs/configuration/basic/#allowlist_external_dirs). Optional.
-- **media_url**: URL of an image/file to download and attach. Used when `attachment` is not set. Optional.
-
-Example automation in YAML:
-
-```yaml
-automation:
-  - alias: Send Test Message
-    trigger:
-      - platform: time
-        at: "12:00:00"
-    action:
-      - service: bluebubbles.send_message
-        data:
-          addresses: "+15551234567, user@example.com"
-          message: "Hello from Home Assistant!"
-```
-
-#### Sending an image
-
-1. Ensure the file path is under an allowed directory, for example:
-
-```yaml
-# configuration.yaml
-homeassistant:
-  allowlist_external_dirs:
-    - /config/www
-```
-
-2. Call the service with an `attachment` path (and optional caption in `message`):
-
-```yaml
-service: bluebubbles.send_message
-data:
-  addresses: "+15551234567"
-  message: "Front door motion"
-  attachment: "/config/www/snapshot.jpg"
-```
-
-Or attach a remote/local HTTP image with `media_url`:
-
-```yaml
-service: bluebubbles.send_message
-data:
-  addresses: "+15551234567"
-  message: "Front door motion"
-  media_url: "https://example.com/snapshot.jpg"
-```
-
-You can also call this service from the Developer Tools > Services page for testing.
-
-## Breaking changes
-
-**None.** Config entries, `send_message` fields, option keys for existing setups, and translations for current outbound use remain compatible. Inbound messaging is additive and disabled until you enable it in Configure.
-
 ## Troubleshooting
 
-- **Connection / Send Errors**: The service surfaces BlueBubbles API error messages in Home Assistant (instead of a generic "Unknown error"). Double-check your host URL and password, and review the Home Assistant log for the redacted response body.
-- **Permission Issues**: If messages aren't sending, verify permissions on your macOS BlueBubbles app as noted in the setup section.
-- **Attachment Path Blocked**: If sending an image fails with an allowlist error, add the directory to `allowlist_external_dirs` and restart Home Assistant.
-- **Group Send Failures**: If sending to multiple addresses fails, ensure Private API is enabled on your BlueBubbles server (check server settings). The integration detects this automatically on setup and restarts.
-- **SSL Problems**: If using HTTPS, try toggling the SSL option.
-- **Can't find BlueBubbles triggers**: Update to **0.6.0** via HACS and reload. Then use **Automations → Add trigger → search BlueBubbles**, or **Device → BlueBubbles → Message received**. Device triggers are not listed under a separate “BlueBubbles” category outside the device picker.
-- **Inbound not firing**: Confirm inbound is enabled under Configure, BlueBubbles has a `new-message` webhook pointing at Home Assistant, and (if using local-only) the Mac is on the same network. Check logs for `bluebubbles` webhook registration lines. Triggers can still be selected when inbound is off; they only fire after inbound is enabled.
-- For other issues, check the Home Assistant logs (search for "bluebubbles") or open an [issue][issue-tracker].
+- **Connection / send errors**: check host URL and password. Home Assistant logs include the redacted BlueBubbles response.
+- **Permissions**: if sends fail, accept the macOS permission prompt on the BlueBubbles host.
+- **Attachment path blocked**: add the directory to `allowlist_external_dirs` and restart Home Assistant.
+- **Group send fails**: enable Private API on the BlueBubbles server.
+- **SSL**: if HTTPS fails, toggle the SSL option.
+- **Inbound not firing**: inbound enabled under Configure, BlueBubbles has a `new-message` webhook pointing at Home Assistant, and (if local-only) the Mac is on the same network. Check Home Assistant logs for `bluebubbles`.
 
-## Contributing
-
-Contributions are welcome! Feel free to submit pull requests or report bugs via the [issue tracker][issue-tracker].
+Other issues: [issue tracker][issue-tracker].
 
 ## License
 
-This integration is licensed under the MIT License. See the [LICENSE][license] file for details.
+MIT. See [LICENSE][license].
 
 [releases]: https://github.com/helv-io/ha-bluebubbles/releases
 [bluebubbles-website]: https://bluebubbles.app
 [bluebubbles-docs]: https://docs.bluebubbles.app
 [issue-tracker]: https://github.com/helv-io/ha-bluebubbles/issues
 [license]: https://github.com/helv-io/ha-bluebubbles/blob/main/LICENSE
-
-## Star History
-Thank you for your support and feedback!
-
-[![Star History Chart](https://api.star-history.com/svg?repos=helv-io/ha-bluebubbles&type=Date)](https://www.star-history.com/#helv-io/ha-bluebubbles&Date)

--- a/custom_components/bluebubbles/manifest.json
+++ b/custom_components/bluebubbles/manifest.json
@@ -16,5 +16,5 @@
     "aiohttp>=3.9.0,<4.0.0"
   ],
   "single_config_entry": true,
-  "version": "0.6.0"
+  "version": "0.7.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ha-bluebubbles",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A project for managing BlueBubbles integration.",
   "author": "Helvio Pedreschi",
   "license": "MIT",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -67,7 +67,7 @@ async def test_diagnostics_redacts_password(
     assert result["inbound_enabled"] is True
     assert result["webhook_path"] == f"/api/webhook/{WEBHOOK_ID}"
     assert result["private_api"] is True
-    assert result["integration_version"] == "0.6.0"
+    assert result["integration_version"] == "0.7.0"
 
     config_data = result["config_entry"]["data"]
     assert config_data[CONF_HOST] == MOCK_HOST


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rewrite the README as a normal HACS custom integration guide: short, factual, no marketing.

**Kept**
- What the integration is
- HACS install (My Button + custom repository)
- Setup fields: host, password, SSL
- `send_message` fields as on main, including optional `chat_guid` (exactly one of `addresses` or `chat_guid`)
- Inbound webhooks and triggers, with two working YAML examples
- Operational troubleshooting
- License and issue tracker links

**Removed**
- Star History / thank-you
- Architecture essay
- Standing 0.6.0 upgrade section
- Breaking-changes manifesto
- Duplicate trigger-finding copy
- Contributing welcome paragraph

Also bumps the integration version from 0.6.0 to 0.7.0 in `manifest.json`, `package.json`, and the diagnostics test assertion. No Python service names or fields changed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9add31d-f5fd-4903-b9fb-5f2cde1bcc96?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9add31d-f5fd-4903-b9fb-5f2cde1bcc96&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

