### PR TITLE
Replace deprecated async_get_device lookups in tests

### DIFF
--- a/tests/test_device_trigger.py
+++ b/tests/test_device_trigger.py
@@ -63,7 +63,9 @@ async def _setup_entry(hass: HomeAssistant, aioclient_mock) -> tuple[MockConfigE
     await hass.async_block_till_done()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
     assert device is not None
     return entry, device.id
 
@@ -102,7 +104,9 @@ async def test_device_triggers_listed_when_inbound_disabled(
     await hass.async_block_till_done()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
     assert device is not None
     triggers = await device_trigger.async_get_triggers(hass, device.id)
     assert {trigger[CONF_TYPE] for trigger in triggers} == {

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -58,7 +58,9 @@ async def _setup_entry(
     await hass.async_block_till_done()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
     assert device is not None
     return entry, device.id
 

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -65,7 +65,9 @@ async def _setup_entry(hass: HomeAssistant, aioclient_mock) -> tuple[MockConfigE
     await hass.async_block_till_done()
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
     assert device is not None
     return entry, device.id
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace four test-only `device_registry.async_get_device` lookups with `async_get_device_by_identifier((DOMAIN, entry.entry_id), entry.entry_id)`.

Call sites:
- `tests/test_trigger.py` (`_setup_entry`)
- `tests/test_event.py` (`_setup_entry`)
- `tests/test_device_trigger.py` (`_setup_entry` and `test_device_triggers_listed_when_inbound_disabled`)

Nightly Tests on main (`79aac4f`) failed because HA now raises `RuntimeError` for `async_get_device`. Production `trigger.py`, `event.py`, and `device_trigger.py` do not call it. They use `async_get_or_create` and `async_get(device_id)`.

No domain, service, or field changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24089d80-82a3-4698-8b13-f8aa95de8d25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24089d80-82a3-4698-8b13-f8aa95de8d25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

